### PR TITLE
feat: display mouse move distance in menu bar widget

### DIFF
--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -623,6 +623,7 @@ final class L10n {
         case .miniChart:      return ja("直近7日グラフ", en: "Last 7 Days Chart")
         case .streak:               return ja("ストリーク", en: "Streak")
         case .shortcutEfficiency:   return ja("ショートカット効率", en: "Shortcut Efficiency")
+        case .mouseDistance:        return ja("マウス移動距離", en: "Mouse Distance")
         }
     }
 
@@ -695,6 +696,26 @@ final class L10n {
 
     var shortcutEfficiencyNoData: String {
         ja("⌨️ ショートカットデータなし", en: "⌨️ No shortcut data yet")
+    }
+
+    // MARK: - Mouse Distance
+
+    /// Mouse distance display string. Points are converted to km or m.
+    func mouseDistanceDisplay(_ pts: Double) -> String {
+        // 1 screen point ≈ 0.264 mm at 96 dpi baseline
+        let meters = pts * 0.000264
+        if meters >= 1000 {
+            let km = meters / 1000
+            return ja(String(format: "🖱 移動距離: %.2f km", km),
+                      en: String(format: "🖱 Distance: %.2f km", km))
+        } else {
+            return ja(String(format: "🖱 移動距離: %.0f m", meters),
+                      en: String(format: "🖱 Distance: %.0f m", meters))
+        }
+    }
+
+    var mouseDistanceNoData: String {
+        ja("🖱 移動距離データなし", en: "🖱 No mouse distance data yet")
     }
 
     // MARK: - Helper

--- a/Sources/KeyLens/MenuView.swift
+++ b/Sources/KeyLens/MenuView.swift
@@ -106,6 +106,12 @@ struct MenuView: View {
                     } else {
                         infoRow(l.shortcutEfficiencyNoData)
                     }
+                case .mouseDistance:
+                    if let pts = MouseStore.shared.distanceToday() {
+                        infoRow(l.mouseDistanceDisplay(pts))
+                    } else {
+                        infoRow(l.mouseDistanceNoData)
+                    }
                 }
             }
         }

--- a/Sources/KeyLens/MenuWidgetStore.swift
+++ b/Sources/KeyLens/MenuWidgetStore.swift
@@ -14,6 +14,7 @@ enum MenuWidget: String, CaseIterable, Identifiable {
     case miniChart            = "miniChart"
     case streak               = "streak"
     case shortcutEfficiency   = "shortcutEfficiency"
+    case mouseDistance        = "mouseDistance"
 
     var id: String { rawValue }
 

--- a/Sources/KeyLens/MouseStore.swift
+++ b/Sources/KeyLens/MouseStore.swift
@@ -146,8 +146,27 @@ final class MouseStore {
     }
 
     /// Synchronous flush — call on app termination to avoid data loss.
-    /// 同期フラッシュ — データ損失を防ぐためアプリ終了時に呼ぶ。
     func flushSync() {
         queue.sync { flushLocked() }
+    }
+
+    // MARK: - Queries
+
+    /// Total mouse travel distance for today in points (screen coordinates).
+    /// Returns nil if no data has been recorded yet.
+    /// Includes in-memory pending distance not yet flushed to disk.
+    func distanceToday() -> Double? {
+        queue.sync {
+            let dateStr = Self.dayFormatter.string(from: Date())
+            var stored: Double = 0
+            if let db = dbQueue {
+                stored = (try? db.read { db in
+                    try Double.fetchOne(db, sql: "SELECT distance_pts FROM mouse_daily WHERE date = ?",
+                                        arguments: [dateStr])
+                }) ?? 0
+            }
+            let total = stored + pendingDistance
+            return total > 0 ? total : nil
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Add `distanceToday()` to `MouseStore` — queries today's distance from SQLite + in-memory pending
- Add `.mouseDistance` case to `MenuWidget` enum
- Display in menu bar popover: `🖱 Distance: 1.2 km` (or `m` for short distances)
- Add bilingual strings to `L10n.swift`

Closes #94