### PR TITLE
refactor: replace string bigrams with typed Bigram struct (#114)

### DIFF
--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -166,9 +166,8 @@ extension KeyCountStore {
             let layout   = LayoutRegistry.shared
             return store.bigramCounts
                 .filter { pair, _ in
-                    let parts = pair.components(separatedBy: "→")
-                    guard parts.count == 2 else { return false }
-                    return detector.isHighStrain(from: parts[0], to: parts[1], layout: layout)
+                    guard let b = Bigram.parse(pair) else { return false }
+                    return detector.isHighStrain(from: b.from, to: b.to, layout: layout)
                 }
                 .sorted { $0.value > $1.value }
                 .prefix(limit)

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -322,7 +322,7 @@ final class KeyCountStore {
                     alternationStreak = 0
                 }
                 // Raw bigram pair frequency (Issue #12)
-                let pair = "\(prev)→\(key)"
+                let pair = Bigram(from: prev, to: key).key
                 store.bigramCounts[pair, default: 0] += 1
                 store.dailyBigramCounts[today, default: [:]][pair, default: 0] += 1
                 // Bigram IKI accumulation (Issue #24)

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import KeyLensCore
 
 // MARK: - HeatmapMode
 
@@ -207,10 +208,9 @@ struct KeyboardHeatmapView: View {
     private var strainScores: [String: Int] {
         var scores: [String: Int] = [:]
         for (pair, count) in KeyCountStore.shared.topHighStrainBigrams(limit: 1000) {
-            let parts = pair.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            scores[parts[0], default: 0] += count
-            scores[parts[1], default: 0] += count
+            guard let b = Bigram.parse(pair) else { continue }
+            scores[b.from, default: 0] += count
+            scores[b.to, default: 0] += count
         }
         return scores
     }

--- a/Sources/KeyLensCore/Bigram.swift
+++ b/Sources/KeyLensCore/Bigram.swift
@@ -1,0 +1,24 @@
+/// A typed value representing a two-key sequence (bigram).
+///
+/// Bigrams are stored in dictionaries using `key` (e.g. `"a→s"`) for JSON
+/// compatibility. Use `Bigram.parse(_:)` to recover the struct from a stored key.
+public struct Bigram: Hashable, Codable {
+    public let from: String
+    public let to: String
+
+    public init(from: String, to: String) {
+        self.from = from
+        self.to   = to
+    }
+
+    /// Stable string key used for dictionary storage (matches the on-disk format).
+    public var key: String { "\(from)→\(to)" }
+
+    /// Parses a stored bigram key (e.g. `"a→s"`) into a `Bigram`.
+    /// Returns `nil` if the string does not contain exactly one `→` separator.
+    public static func parse(_ key: String) -> Bigram? {
+        let parts = key.components(separatedBy: "→")
+        guard parts.count == 2 else { return nil }
+        return Bigram(from: parts[0], to: parts[1])
+    }
+}

--- a/Sources/KeyLensCore/ErgonomicSnapshot.swift
+++ b/Sources/KeyLensCore/ErgonomicSnapshot.swift
@@ -146,9 +146,8 @@ public struct ErgonomicSnapshot: Equatable {
         let detector   = layout.highStrainDetector
 
         for (bigram, count) in bigramCounts where count > 0 {
-            let parts = bigram.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            let (k1, k2) = (parts[0], parts[1])
+            guard let b = Bigram.parse(bigram) else { continue }
+            let (k1, k2) = (b.from, b.to)
 
             totalPairs += count
 

--- a/Sources/KeyLensCore/FullErgonomicOptimizer.swift
+++ b/Sources/KeyLensCore/FullErgonomicOptimizer.swift
@@ -142,10 +142,9 @@ public struct FullErgonomicOptimizer {
     private func keysInData(_ bigramCounts: [String: Int], _ keyCounts: [String: Int]) -> Set<String> {
         var keys = Set(keyCounts.keys)
         for bigram in bigramCounts.keys {
-            let parts = bigram.components(separatedBy: "→")
-            if parts.count == 2 {
-                keys.insert(parts[0])
-                keys.insert(parts[1])
+            if let b = Bigram.parse(bigram) {
+                keys.insert(b.from)
+                keys.insert(b.to)
             }
         }
         return keys

--- a/Sources/KeyLensCore/KeyboardLayout.swift
+++ b/Sources/KeyLensCore/KeyboardLayout.swift
@@ -443,9 +443,8 @@ public final class LayoutRegistry {
     /// キー名ビグラム文字列（例："f→r"）に対する同指ペナルティを返す。
     /// 未知キー・異指・異手の場合は nil。
     public func sameFingerPenalty(for bigram: String) -> Double? {
-        let parts = bigram.components(separatedBy: "→")
-        guard parts.count == 2 else { return nil }
-        let (k1, k2) = (parts[0], parts[1])
+        guard let b = Bigram.parse(bigram) else { return nil }
+        let (k1, k2) = (b.from, b.to)
 
         // Both keys must be on the same hand and use the same finger.
         // 同じ手・同じ指でなければ同指ビグラムではない。

--- a/Sources/KeyLensCore/SFBScoreEngine.swift
+++ b/Sources/KeyLensCore/SFBScoreEngine.swift
@@ -68,9 +68,8 @@ public struct SFBScoreEngine {
     public func score(bigramCounts: [String: Int], layout: any KeyboardLayout) -> Double {
         var total = 0.0
         for (bigram, count) in bigramCounts where count > 0 {
-            let parts = bigram.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            let k1 = parts[0], k2 = parts[1]
+            guard let b = Bigram.parse(bigram) else { continue }
+            let k1 = b.from, k2 = b.to
             // Only same-hand, same-finger bigrams contribute to the SFB penalty.
             // Left-index and right-index are different fingers — hand must also match.
             // 同手・同指ビグラムのみがSFBペナルティに寄与する。

--- a/Sources/KeyLensCore/SameFingerOptimizer.swift
+++ b/Sources/KeyLensCore/SameFingerOptimizer.swift
@@ -165,10 +165,9 @@ public struct SameFingerOptimizer {
     private func keysInBigrams(_ bigramCounts: [String: Int]) -> Set<String> {
         var keys = Set<String>()
         for bigram in bigramCounts.keys {
-            let parts = bigram.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            keys.insert(parts[0])
-            keys.insert(parts[1])
+            guard let b = Bigram.parse(bigram) else { continue }
+            keys.insert(b.from)
+            keys.insert(b.to)
         }
         return keys
     }
@@ -185,9 +184,8 @@ public struct SameFingerOptimizer {
         // Score each same-finger bigram by count × penalty.
         var scored: [(key1: String, key2: String, weight: Double)] = []
         for (bigram, count) in bigramCounts where count > 0 {
-            let parts = bigram.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            let k1 = parts[0], k2 = parts[1]
+            guard let b = Bigram.parse(bigram) else { continue }
+            let k1 = b.from, k2 = b.to
             guard let f1 = layout.finger(for: k1),
                   let f2 = layout.finger(for: k2),
                   f1 == f2,

--- a/Sources/KeyLensCore/TravelDistanceEstimator.swift
+++ b/Sources/KeyLensCore/TravelDistanceEstimator.swift
@@ -82,10 +82,9 @@ public struct TravelDistanceEstimator {
     public func totalTravel(counts: [String: Int], layout: any KeyboardLayout) -> Double {
         var total = 0.0
         for (bigram, count) in counts where count > 0 {
-            let parts = bigram.components(separatedBy: "→")
-            guard parts.count == 2 else { continue }
-            guard let p1 = layout.position(for: parts[0]),
-                  let p2 = layout.position(for: parts[1]) else { continue }
+            guard let b = Bigram.parse(bigram) else { continue }
+            guard let p1 = layout.position(for: b.from),
+                  let p2 = layout.position(for: b.to) else { continue }
             total += Double(count) * distance(from: p1, to: p2)
         }
         return total


### PR DESCRIPTION
## Summary
- Add `Sources/KeyLensCore/Bigram.swift`: lightweight `Bigram` struct with `key` (formation) and `parse(_:)` (parsing)
- Replace all `"\(a)→\(b)"` formation sites with `Bigram(from:to:).key`
- Replace all `.components(separatedBy: "→")` parsing sites (9 total across 8 files) with `Bigram.parse(_:)`

No data format change — stored keys remain `"a→b"` strings for JSON compatibility.

## Files changed
- `Sources/KeyLensCore/Bigram.swift` *(new)*
- `Sources/KeyLens/KeyCountStore.swift`
- `Sources/KeyLens/KeyCountStore+Ergonomics.swift`
- `Sources/KeyLens/KeyboardHeatmapView.swift`
- `Sources/KeyLensCore/TravelDistanceEstimator.swift`
- `Sources/KeyLensCore/ErgonomicSnapshot.swift`
- `Sources/KeyLensCore/FullErgonomicOptimizer.swift`
- `Sources/KeyLensCore/SFBScoreEngine.swift`
- `Sources/KeyLensCore/SameFingerOptimizer.swift`
- `Sources/KeyLensCore/KeyboardLayout.swift`

## Test plan
- [ ] Build passes (`./build.sh`) ✅
- [ ] Launch app, verify ergonomics tab and heatmap display normally
- [ ] Confirm bigram counts in counts.json are still loaded and displayed correctly