### PR TITLE
feat: migrate per-day data storage from JSON to SQLite

### DIFF
--- a/Sources/KeyLens/AppDelegate.swift
+++ b/Sources/KeyLens/AppDelegate.swift
@@ -97,8 +97,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
-        // Flush pending mouse distance data to SQLite before exit.
-        // 終了前にマウス移動データを SQLite へフラッシュする。
+        // Flush pending keystroke data to keylens.db before exit.
+        KeyCountStore.shared.flushSync()
+        // Flush pending mouse distance data to mouse.db before exit.
         MouseStore.shared.flushSync()
     }
 

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -154,3 +154,13 @@ struct WeeklyDeltaRow: Identifiable {
     let lowerIsBetter: Bool
     var delta: Double { thisWeek - lastWeek }
 }
+
+/// One bucket in the IKI histogram (Issue #102).
+/// IKIヒストグラムの1バケット。
+struct IKIHistogramEntry: Identifiable {
+    let id = UUID()
+    let bucket: String      // label e.g. "0–50", "50–100", …, "300+"
+    let count: Int          // total keystrokes whose IKI fell in this bucket
+    let percentage: Double  // count / total * 100
+}
+

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import KeyLensCore
 
 // MARK: - Activity & frequency queries
@@ -8,21 +9,29 @@ extension KeyCountStore {
 
     /// Today's top limit keys sorted descending.
     func todayTopKeys(limit: Int = 10) -> [(key: String, count: Int)] {
-        queue.sync { topEntries(store.dailyCounts[todayKey] ?? [:], limit: limit) }
+        queue.sync { topEntries(dailyKeyCountsLocked(for: todayKey), limit: limit) }
     }
 
-    /// Today's total keystroke count.
+    /// Today's total keystroke count (SQLite + pending).
     var todayCount: Int {
-        queue.sync { store.dailyCounts[todayKey]?.values.reduce(0, +) ?? 0 }
+        queue.sync { dailyTotalLocked(for: todayKey) }
     }
 
     /// Hourly keystroke counts for a given date (24-element array, index = hour 0–23).
     func hourlyCounts(for date: String) -> [Int] {
         queue.sync {
-            (0..<24).map { hour in
-                let key = String(format: "%@-%02d", date, hour)
-                return store.hourlyCounts[key] ?? 0
+            var result = [Int](repeating: 0, count: 24)
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT hour, count FROM hourly_counts WHERE date = ?", arguments: [date])
+               }) {
+                for row in rows {
+                    let h: Int = row["hour"]
+                    if h < 24 { result[h] += (row["count"] as Int) }
+                }
             }
+            for (h, v) in pending.hourly[date, default: [:]] where h < 24 { result[h] += v }
+            return result
         }
     }
 
@@ -30,7 +39,7 @@ extension KeyCountStore {
     func shortcutEfficiencyToday() -> Double? {
         queue.sync {
             let shortcuts = store.dailyModifiedCount[todayKey] ?? 0
-            let dayCounts = store.dailyCounts[todayKey] ?? [:]
+            let dayCounts = dailyKeyCountsLocked(for: todayKey)
             let mouseClicks = dayCounts.filter { $0.key.hasPrefix("🖱") }.values.reduce(0, +)
             let total = shortcuts + mouseClicks
             guard total > 0 else { return nil }
@@ -105,12 +114,34 @@ extension KeyCountStore {
 
     /// Today's top apps sorted descending.
     func todayTopApps(limit: Int = 10) -> [(app: String, count: Int)] {
-        queue.sync { topEntries(store.dailyAppCounts[todayKey] ?? [:], limit: limit) }
+        let today = todayKey
+        return queue.sync {
+            var result: [String: Int] = [:]
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT app, count FROM daily_apps WHERE date = ?", arguments: [today])
+               }) {
+                for row in rows { result[row["app"], default: 0] += (row["count"] as Int) }
+            }
+            for (a, v) in pending.dailyApps[today, default: [:]] { result[a, default: 0] += v }
+            return topEntries(result, limit: limit)
+        }
     }
 
     /// Today's top devices sorted descending.
     func todayTopDevices(limit: Int = 10) -> [(device: String, count: Int)] {
-        queue.sync { topEntries(store.dailyDeviceCounts[todayKey] ?? [:], limit: limit) }
+        let today = todayKey
+        return queue.sync {
+            var result: [String: Int] = [:]
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT device, count FROM daily_devices WHERE date = ?", arguments: [today])
+               }) {
+                for row in rows { result[row["device"], default: 0] += (row["count"] as Int) }
+            }
+            for (d, v) in pending.dailyDevices[today, default: [:]] { result[d, default: 0] += v }
+            return topEntries(result, limit: limit)
+        }
     }
 
     /// Full cumulative bigram frequency table. Used by ErgonomicSnapshot / LayoutComparison.
@@ -118,74 +149,126 @@ extension KeyCountStore {
         queue.sync { store.bigramCounts }
     }
 
-    /// Full cumulative per-key keystroke counts. Used for thumb imbalance and efficiency metrics.
+    /// Full cumulative per-key keystroke counts.
     var allKeyCounts: [String: Int] {
         queue.sync { store.counts }
     }
 
-    /// Top-N bigrams by cumulative count (Issue #12).
+    /// Top-N bigrams by cumulative count.
     func topBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
         queue.sync { topEntries(store.bigramCounts, limit: limit) }
     }
 
-    /// Today's top bigrams (Issue #12).
+    /// Today's top bigrams.
     func todayTopBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
         let today = todayKey
-        return queue.sync { topEntries(store.dailyBigramCounts[today] ?? [:], limit: limit) }
+        return queue.sync {
+            var result: [String: Int] = [:]
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT bigram, count FROM daily_bigrams WHERE date = ?", arguments: [today])
+               }) {
+                for row in rows { result[row["bigram"], default: 0] += (row["count"] as Int) }
+            }
+            for (b, v) in pending.dailyBigrams[today, default: [:]] { result[b, default: 0] += v }
+            return topEntries(result, limit: limit)
+        }
     }
 
-    /// Top-N trigrams by cumulative frequency (Issue #12).
+    /// Top-N trigrams by cumulative frequency.
     func topTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
         queue.sync { topEntries(store.trigramCounts, limit: limit) }
     }
 
-    /// Today's top trigrams (Issue #12).
+    /// Today's top trigrams.
     func todayTopTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
         let today = todayKey
-        return queue.sync { topEntries(store.dailyTrigramCounts[today] ?? [:], limit: limit) }
+        return queue.sync {
+            var result: [String: Int] = [:]
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT trigram, count FROM daily_trigrams WHERE date = ?", arguments: [today])
+               }) {
+                for row in rows { result[row["trigram"], default: 0] += (row["count"] as Int) }
+            }
+            for (t, v) in pending.dailyTrigrams[today, default: [:]] { result[t, default: 0] += v }
+            return topEntries(result, limit: limit)
+        }
     }
 
     /// Average IKI (ms) for a bigram. Returns nil if no samples exist (Issue #24).
     func avgBigramIKI(for bigram: String) -> Double? {
         queue.sync {
-            guard let count = store.bigramIKICount[bigram], count > 0 else { return nil }
-            return store.bigramIKISum[bigram].map { $0 / Double(count) }
+            var sum: Double = 0
+            var count: Int  = 0
+            if let db = dbQueue,
+               let row = try? db.read({ db in
+                   try Row.fetchOne(db, sql: "SELECT iki_sum, iki_count FROM bigram_iki WHERE bigram = ?", arguments: [bigram])
+               }) {
+                sum   = row["iki_sum"]   ?? 0
+                count = row["iki_count"] ?? 0
+            }
+            if let p = pending.bigramIKI[bigram] { sum += p.sum; count += p.count }
+            guard count > 0 else { return nil }
+            return sum / Double(count)
         }
     }
 
     /// All daily totals sorted ascending by date.
     func dailyTotals() -> [(date: String, total: Int)] {
         queue.sync {
-            store.dailyCounts
-                .map { (date: $0.key, total: $0.value.values.reduce(0, +)) }
-                .sorted { $0.date < $1.date }
+            guard let db = dbQueue else { return [] }
+            var map: [String: Int] = [:]
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: "SELECT date, SUM(count) as total FROM daily_keys GROUP BY date ORDER BY date")
+            }) {
+                for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
+            }
+            for (date, keys) in pending.dailyKeys { map[date, default: 0] += keys.values.reduce(0, +) }
+            return map.sorted { $0.key < $1.key }.map { (date: $0.key, total: $0.value) }
         }
     }
 
     /// Per-day keystroke totals for the last N calendar days (oldest first).
     func dailyTotals(last days: Int) -> [(date: String, count: Int)] {
         let cal = Calendar.current
+        let cutoffDate = cal.date(byAdding: .day, value: -(days - 1), to: Date()) ?? Date()
         return queue.sync {
-            (0..<days).reversed().compactMap { offset -> (String, Int)? in
+            guard let db = dbQueue else { return [] }
+            let cutoff = Self.dayFormatter.string(from: cutoffDate)
+            var map: [String: Int] = [:]
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date, SUM(count) as total FROM daily_keys WHERE date >= ? GROUP BY date
+                    """, arguments: [cutoff])
+            }) {
+                for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
+            }
+            for (date, keys) in pending.dailyKeys where date >= cutoff {
+                map[date, default: 0] += keys.values.reduce(0, +)
+            }
+            return (0..<days).reversed().compactMap { offset -> (String, Int)? in
                 guard let date = cal.date(byAdding: .day, value: -offset, to: Date()) else { return nil }
                 let key = Self.dayFormatter.string(from: date)
-                let count = store.dailyCounts[key]?.values.reduce(0, +) ?? 0
-                return (key, count)
+                return (key, map[key] ?? 0)
             }
         }
     }
 
     /// Aggregate hourly keystroke counts across all recorded dates.
-    /// Returns a 24-element array where index = hour of day (0–23).
     func hourlyDistribution() -> [Int] {
         queue.sync {
             var result = [Int](repeating: 0, count: 24)
-            for (key, count) in store.hourlyCounts {
-                // key format: "yyyy-MM-dd-HH"
-                let parts = key.split(separator: "-")
-                guard parts.count == 4, let hour = Int(parts[3]), hour < 24 else { continue }
-                result[hour] += count
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT hour, SUM(count) as total FROM hourly_counts GROUP BY hour")
+               }) {
+                for row in rows {
+                    let h: Int = row["hour"]
+                    if h < 24 { result[h] += (row["total"] as Int) }
+                }
             }
+            for (_, hours) in pending.hourly { for (h, v) in hours where h < 24 { result[h] += v } }
             return result
         }
     }
@@ -193,15 +276,22 @@ extension KeyCountStore {
     /// Aggregate total keystrokes by calendar month ("yyyy-MM"), sorted ascending.
     func monthlyTotals() -> [(month: String, total: Int)] {
         queue.sync {
-            var monthMap: [String: Int] = [:]
-            for (date, keyCounts) in store.dailyCounts {
+            guard let db = dbQueue else { return [] }
+            var map: [String: Int] = [:]
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT SUBSTR(date,1,7) as month, SUM(count) as total
+                    FROM daily_keys GROUP BY month ORDER BY month
+                    """)
+            }) {
+                for row in rows { map[row["month"], default: 0] = (row["total"] as Int) }
+            }
+            for (date, keys) in pending.dailyKeys {
                 guard date.count >= 7 else { continue }
                 let month = String(date.prefix(7))
-                monthMap[month, default: 0] += keyCounts.values.reduce(0, +)
+                map[month, default: 0] += keys.values.reduce(0, +)
             }
-            return monthMap
-                .map { (month: $0.key, total: $0.value) }
-                .sorted { $0.month < $1.month }
+            return map.sorted { $0.key < $1.key }.map { (month: $0.key, total: $0.value) }
         }
     }
 
@@ -222,17 +312,33 @@ extension KeyCountStore {
     /// Top limit keys per day over the most recent recentDays days.
     func topKeysPerDay(limit: Int = 10, recentDays: Int = 14) -> [(date: String, key: String, count: Int)] {
         queue.sync {
-            let dates = Array(store.dailyCounts.keys.sorted().suffix(recentDays))
-            var combined: [String: Int] = [:]
-            for date in dates {
-                for (k, v) in store.dailyCounts[date] ?? [:] {
-                    combined[k, default: 0] += v
+            guard let db = dbQueue else { return [] }
+            let cal = Calendar.current
+            let cutoffDate = cal.date(byAdding: .day, value: -recentDays, to: Date()) ?? Date()
+            let cutoff = Self.dayFormatter.string(from: cutoffDate)
+
+            // Load all rows in range
+            var dateMap: [String: [String: Int]] = [:]
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: "SELECT date, key, count FROM daily_keys WHERE date >= ? ORDER BY date", arguments: [cutoff])
+            }) {
+                for row in rows {
+                    dateMap[row["date"], default: [:]][row["key"], default: 0] += (row["count"] as Int)
                 }
             }
+            for (date, keys) in pending.dailyKeys where date >= cutoff {
+                for (k, v) in keys { dateMap[date, default: [:]][k, default: 0] += v }
+            }
+
+            // Compute top keys across the range
+            var combined: [String: Int] = [:]
+            for (_, keys) in dateMap { for (k, v) in keys { combined[k, default: 0] += v } }
             let topKeyNames = topEntries(combined, limit: limit).map { $0.0 }
+
+            let dates = Array(dateMap.keys.sorted().suffix(recentDays))
             var result: [(date: String, key: String, count: Int)] = []
             for date in dates {
-                let dayCounts = store.dailyCounts[date] ?? [:]
+                let dayCounts = dateMap[date] ?? [:]
                 for key in topKeyNames {
                     result.append((date: date, key: key, count: dayCounts[key] ?? 0))
                 }
@@ -249,7 +355,7 @@ extension KeyCountStore {
     /// All keys sorted by cumulative count descending, including today's count.
     func allEntries() -> [(key: String, total: Int, today: Int)] {
         queue.sync {
-            let todayData = store.dailyCounts[todayKey] ?? [:]
+            let todayData = dailyKeyCountsLocked(for: todayKey)
             return store.counts.sorted { $0.value > $1.value }
                 .map { (key: $0.key, total: $0.value, today: todayData[$0.key] ?? 0) }
         }
@@ -261,7 +367,7 @@ extension KeyCountStore {
 extension KeyCountStore {
 
     /// Returns the top-N entries from a [String: Int] dictionary, sorted by value descending.
-    /// Must be called from inside `queue.sync` — does not re-acquire the queue.
+    /// Must be called from inside `queue.sync`.
     func topEntries(_ dict: [String: Int], limit: Int) -> [(String, Int)] {
         dict.sorted { $0.value > $1.value }
             .prefix(limit)

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GRDB
 import KeyLensCore
 
 // MARK: - Ergonomic queries
@@ -29,7 +30,7 @@ extension KeyCountStore {
     /// Today's backspace rate (%).
     var todayBackspaceRate: Double? {
         queue.sync {
-            let dayCounts = store.dailyCounts[todayKey] ?? [:]
+            let dayCounts = dailyKeyCountsLocked(for: todayKey)
             let total = dayCounts.values.reduce(0, +)
             guard total > 0 else { return nil }
             return Double(dayCounts["Delete", default: 0]) / Double(total) * 100.0
@@ -39,17 +40,37 @@ extension KeyCountStore {
     /// Returns per-day backspace rate sorted ascending. Days with zero keystrokes are excluded.
     func dailyBackspaceRates() -> [(date: String, rate: Double)] {
         queue.sync {
-            store.dailyCounts.compactMap { date, dayCounts -> (date: String, rate: Double)? in
-                let total = dayCounts.values.reduce(0, +)
-                guard total > 0 else { return nil }
-                let bs = dayCounts["Delete", default: 0]
-                return (date, Double(bs) / Double(total) * 100.0)
+            guard let db = dbQueue else { return [] }
+            let today = todayKey
+            // Historical dates (before today) via a single SQL aggregation
+            var result: [(date: String, rate: Double)] = []
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date,
+                           SUM(count) as total,
+                           SUM(CASE WHEN key = 'Delete' THEN count ELSE 0 END) as deletes
+                    FROM daily_keys WHERE date < ?
+                    GROUP BY date HAVING total > 0 ORDER BY date
+                    """, arguments: [today])
+            }) {
+                for row in rows {
+                    let total: Int = row["total"]
+                    guard total > 0 else { continue }
+                    result.append((row["date"], Double(row["deletes"] as Int) / Double(total) * 100.0))
+                }
             }
-            .sorted { $0.date < $1.date }
+            // Today: merge SQL + pending for accuracy
+            let todayCounts = dailyKeyCountsLocked(for: today)
+            let todayTotal  = todayCounts.values.reduce(0, +)
+            if todayTotal > 0 {
+                let bs = todayCounts["Delete", default: 0]
+                result.append((today, Double(bs) / Double(todayTotal) * 100.0))
+            }
+            return result
         }
     }
 
-    /// Returns per-day estimated WPM sorted by date ascending. Only days with accumulated data are included.
+    /// Returns per-day estimated WPM sorted by date ascending.
     func dailyWPM() -> [(date: String, wpm: Double)] {
         queue.sync {
             store.dailyAvgIntervalMs.compactMap { date, avgMs -> (date: String, wpm: Double)? in
@@ -66,7 +87,7 @@ extension KeyCountStore {
         return queue.sync { store.dailyMinIntervalMs[key] }
     }
 
-    /// Cumulative same-finger bigram rate. Returns nil if no bigrams recorded.
+    /// Cumulative same-finger bigram rate.
     var sameFingerRate: Double? {
         queue.sync {
             guard store.totalBigramCount > 0 else { return nil }
@@ -74,18 +95,17 @@ extension KeyCountStore {
         }
     }
 
-    /// Today's same-finger bigram rate. Returns nil if no bigrams recorded today.
+    /// Today's same-finger bigram rate.
     var todaySameFingerRate: Double? {
         let today = todayKey
         return queue.sync {
             let total = store.dailyTotalBigramCount[today] ?? 0
             guard total > 0 else { return nil }
-            let same = store.dailySameFingerCount[today] ?? 0
-            return Double(same) / Double(total)
+            return Double(store.dailySameFingerCount[today] ?? 0) / Double(total)
         }
     }
 
-    /// Cumulative hand-alternation rate. Returns nil if no bigrams recorded.
+    /// Cumulative hand-alternation rate.
     var handAlternationRate: Double? {
         queue.sync {
             guard store.totalBigramCount > 0 else { return nil }
@@ -93,23 +113,22 @@ extension KeyCountStore {
         }
     }
 
-    /// Today's hand-alternation rate. Returns nil if no bigrams recorded today.
+    /// Today's hand-alternation rate.
     var todayHandAlternationRate: Double? {
         let today = todayKey
         return queue.sync {
             let total = store.dailyTotalBigramCount[today] ?? 0
             guard total > 0 else { return nil }
-            let alt = store.dailyHandAlternationCount[today] ?? 0
-            return Double(alt) / Double(total)
+            return Double(store.dailyHandAlternationCount[today] ?? 0) / Double(total)
         }
     }
 
-    /// Cumulative alternation reward score (Issue #25). Includes streak multiplier bonus.
+    /// Cumulative alternation reward score (Issue #25).
     var alternationRewardScore: Double {
         queue.sync { store.alternationRewardScore }
     }
 
-    /// Cumulative thumb imbalance ratio (Issue #26). Returns nil if no thumb keystrokes recorded.
+    /// Cumulative thumb imbalance ratio (Issue #26).
     var thumbImbalanceRatio: Double? {
         queue.sync {
             LayoutRegistry.shared.thumbImbalanceDetector
@@ -120,17 +139,17 @@ extension KeyCountStore {
     /// Thumb imbalance ratio for a specific day (Issue #26).
     func dailyThumbImbalance(for date: String) -> Double? {
         queue.sync {
-            guard let dayCounts = store.dailyCounts[date] else { return nil }
+            let dayCounts = dailyKeyCountsLocked(for: date)
+            guard !dayCounts.isEmpty else { return nil }
             return LayoutRegistry.shared.thumbImbalanceDetector
                 .imbalanceRatio(counts: dayCounts, layout: LayoutRegistry.shared)
         }
     }
 
     /// Per-day ergonomic rates for Learning Curve visualization (Phase 3).
-    /// Returns rows only for dates that have at least one bigram recorded.
     func dailyErgonomicRates() -> [(date: String, sameFingerRate: Double, handAltRate: Double, highStrainRate: Double)] {
         queue.sync {
-            store.dailyCounts.keys.sorted().compactMap { date in
+            allDatesLocked().compactMap { date in
                 let bigrams = store.dailyTotalBigramCount[date] ?? 0
                 guard bigrams > 0 else { return nil }
                 let sf = Double(store.dailySameFingerCount[date]       ?? 0) / Double(bigrams)
@@ -146,7 +165,7 @@ extension KeyCountStore {
         queue.sync { store.highStrainBigramCount }
     }
 
-    /// Fraction of all bigrams that are high-strain. Returns nil if no bigrams recorded.
+    /// Fraction of all bigrams that are high-strain.
     var highStrainBigramRate: Double? {
         queue.sync {
             guard store.totalBigramCount > 0 else { return nil }
@@ -175,7 +194,7 @@ extension KeyCountStore {
         }
     }
 
-    /// Thumb efficiency coefficient (Issue #27). Returns nil if no keystrokes recorded.
+    /// Thumb efficiency coefficient (Issue #27).
     var thumbEfficiencyCoefficient: Double? {
         queue.sync {
             LayoutRegistry.shared.thumbEfficiencyCalculator
@@ -183,8 +202,7 @@ extension KeyCountStore {
         }
     }
 
-    /// Unified ergonomic score (0–100) computed from cumulative keystroke data (Issue #29).
-    /// Higher is better. Returns 100.0 when no bigram data is available.
+    /// Unified ergonomic score (0–100) from cumulative keystroke data (Issue #29).
     var currentErgonomicScore: Double {
         queue.sync {
             ergonomicScore(
@@ -199,9 +217,7 @@ extension KeyCountStore {
 
     /// Inferred typing style based on cumulative data.
     public var currentTypingStyle: TypingStyle {
-        queue.sync {
-            TypingStyleAnalyzer().analyze(keyCounts: store.counts)
-        }
+        queue.sync { TypingStyleAnalyzer().analyze(keyCounts: store.counts) }
     }
 
     /// Detected fatigue risk level.
@@ -219,11 +235,10 @@ extension KeyCountStore {
     }
 
     /// Per-day ergonomic scores for trend tracking (Issue #29).
-    /// Keys are "yyyy-MM-dd" strings. Only dates with at least one bigram are included.
     var dailyErgonomicScore: [String: Double] {
         queue.sync {
             var result: [String: Double] = [:]
-            for date in store.dailyCounts.keys {
+            for date in allDatesLocked() {
                 let bigrams = store.dailyTotalBigramCount[date] ?? 0
                 guard bigrams > 0 else { continue }
                 result[date] = ergonomicScore(
@@ -231,7 +246,7 @@ extension KeyCountStore {
                     hsCount:     store.dailyHighStrainBigramCount[date] ?? 0,
                     altCount:    store.dailyHandAlternationCount[date]  ?? 0,
                     bigramCount: bigrams,
-                    keyCounts:   store.dailyCounts[date] ?? [:]
+                    keyCounts:   dailyKeyCountsLocked(for: date)
                 )
             }
             return result
@@ -244,10 +259,7 @@ extension KeyCountStore {
 extension KeyCountStore {
 
     /// Computes a unified ergonomic score (0–100) from raw bigram counters.
-    /// Must be called from inside `queue.sync` — does not re-acquire the queue.
-    /// - Parameter keyCounts: Per-key counts used to compute thumb metrics.
-    ///   Pass `nil` (or omit) when per-key counts are unavailable (e.g. per-app/device context);
-    ///   thumb imbalance and efficiency will be treated as 0.
+    /// Must be called from inside `queue.sync`.
     func ergonomicScore(
         sfCount:     Int,
         hsCount:     Int,

--- a/Sources/KeyLens/KeyCountStore+Export.swift
+++ b/Sources/KeyLens/KeyCountStore+Export.swift
@@ -20,86 +20,36 @@ extension KeyCountStore {
 
     /// Daily CSV (date, key, count) — per-day breakdown sorted by date and count.
     func exportDailyCSV() -> String {
-        queue.sync {
+        // Flush pending data first so the export is complete.
+        flushSync()
+        return queue.sync {
+            guard let db = dbQueue else { return "date,key,count\n" }
             var lines = ["date,key,count"]
-            for date in store.dailyCounts.keys.sorted() {
-                let dayCounts = store.dailyCounts[date] ?? [:]
-                for (key, count) in dayCounts.sorted(by: { $0.value > $1.value }) {
-                    let escaped = key.contains(",") ? "\"\(key)\"" : key
-                    lines.append("\(date),\(escaped),\(count)")
-                }
+            let rows = (try? db.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date, key, count FROM daily_keys ORDER BY date, count DESC
+                    """)
+            }) ?? []
+            for row in rows {
+                let key: String = row["key"]
+                let escaped = key.contains(",") ? "\"\(key)\"" : key
+                lines.append("\(row["date"] as String),\(escaped),\(row["count"] as Int)")
             }
             return lines.joined(separator: "\n")
         }
     }
 
     /// Export all keystroke data to a SQLite database at the given URL.
-    /// Tables created:
-    ///   key_counts    — all-time total per key
-    ///   daily_counts  — per-day count per key
-    ///   hourly_counts — per-hour total keystrokes (key = "yyyy-MM-dd HH")
-    ///   bigram_counts — all-time bigram (two-key sequence) totals
+    /// Uses GRDB backup to safely copy the live keylens.db to the destination.
     func exportSQLite(to url: URL) throws {
-        // Snapshot data under the serial queue to avoid holding it during DB writes.
-        let (counts, dailyCounts, hourlyCounts, bigramCounts): (
-            [String: Int], [String: [String: Int]], [String: Int], [String: Int]
-        ) = queue.sync {
-            (store.counts, store.dailyCounts, store.hourlyCounts, store.bigramCounts)
+        // Flush pending so the copy is up-to-date.
+        flushSync()
+        guard let src = dbQueue else { return }
+        // Remove any existing file at the destination.
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
         }
-
-        let db = try DatabaseQueue(path: url.path)
-        try db.write { db in
-            // key_counts
-            try db.execute(sql: """
-                CREATE TABLE IF NOT EXISTS key_counts (
-                    key   TEXT PRIMARY KEY,
-                    total INTEGER NOT NULL
-                )
-            """)
-            for (key, total) in counts {
-                try db.execute(sql: "INSERT OR REPLACE INTO key_counts (key, total) VALUES (?, ?)",
-                               arguments: [key, total])
-            }
-
-            // daily_counts
-            try db.execute(sql: """
-                CREATE TABLE IF NOT EXISTS daily_counts (
-                    date  TEXT NOT NULL,
-                    key   TEXT NOT NULL,
-                    count INTEGER NOT NULL,
-                    PRIMARY KEY (date, key)
-                )
-            """)
-            for (date, dayCounts) in dailyCounts {
-                for (key, count) in dayCounts {
-                    try db.execute(sql: "INSERT OR REPLACE INTO daily_counts (date, key, count) VALUES (?, ?, ?)",
-                                   arguments: [date, key, count])
-                }
-            }
-
-            // hourly_counts
-            try db.execute(sql: """
-                CREATE TABLE IF NOT EXISTS hourly_counts (
-                    hour  TEXT PRIMARY KEY,
-                    count INTEGER NOT NULL
-                )
-            """)
-            for (hour, count) in hourlyCounts {
-                try db.execute(sql: "INSERT OR REPLACE INTO hourly_counts (hour, count) VALUES (?, ?)",
-                               arguments: [hour, count])
-            }
-
-            // bigram_counts
-            try db.execute(sql: """
-                CREATE TABLE IF NOT EXISTS bigram_counts (
-                    bigram TEXT PRIMARY KEY,
-                    count  INTEGER NOT NULL
-                )
-            """)
-            for (bigram, count) in bigramCounts {
-                try db.execute(sql: "INSERT OR REPLACE INTO bigram_counts (bigram, count) VALUES (?, ?)",
-                               arguments: [bigram, count])
-            }
-        }
+        let dest = try DatabaseQueue(path: url.path)
+        try src.backup(to: dest)
     }
 }

--- a/Sources/KeyLens/KeyCountStore+Migration.swift
+++ b/Sources/KeyLens/KeyCountStore+Migration.swift
@@ -1,0 +1,151 @@
+import Foundation
+import GRDB
+
+// MARK: - One-time migration: counts.json → keylens.db
+// Reads legacy fields from counts.json and bulk-inserts them into SQLite.
+// Runs once on first launch after update; guarded by a UserDefaults flag.
+
+extension KeyCountStore {
+
+    private static let migrationFlagKey = "com.keylens.sqliteMigrationV1"
+
+    func migrateIfNeeded() {
+        guard !UserDefaults.standard.bool(forKey: Self.migrationFlagKey) else { return }
+        guard let db = dbQueue else {
+            KeyLens.log("KeyCountStore: migration skipped — no database")
+            return
+        }
+
+        guard let jsonData = try? Data(contentsOf: saveURL) else {
+            // No counts.json → fresh install, nothing to migrate
+            UserDefaults.standard.set(true, forKey: Self.migrationFlagKey)
+            return
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        guard let legacy = try? decoder.decode(LegacyCounts.self, from: jsonData) else {
+            KeyLens.log("KeyCountStore: migration failed — could not decode counts.json")
+            UserDefaults.standard.set(true, forKey: Self.migrationFlagKey)
+            return
+        }
+
+        var totalRows = 0
+
+        do {
+            try db.write { db in
+                // daily_keys
+                for (date, keyCounts) in legacy.dailyCounts {
+                    for (key, count) in keyCounts where count > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_keys (date, key, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, key) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, key, count])
+                        totalRows += 1
+                    }
+                }
+                // daily_bigrams
+                for (date, bigramCounts) in legacy.dailyBigramCounts {
+                    for (bigram, count) in bigramCounts where count > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_bigrams (date, bigram, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, bigram) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, bigram, count])
+                        totalRows += 1
+                    }
+                }
+                // daily_trigrams
+                for (date, trigramCounts) in legacy.dailyTrigramCounts {
+                    for (trigram, count) in trigramCounts where count > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_trigrams (date, trigram, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, trigram) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, trigram, count])
+                        totalRows += 1
+                    }
+                }
+                // daily_apps
+                for (date, appCounts) in legacy.dailyAppCounts {
+                    for (app, count) in appCounts where count > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_apps (date, app, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, app) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, app, count])
+                        totalRows += 1
+                    }
+                }
+                // daily_devices
+                for (date, deviceCounts) in legacy.dailyDeviceCounts {
+                    for (device, count) in deviceCounts where count > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_devices (date, device, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, device) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, device, count])
+                        totalRows += 1
+                    }
+                }
+                // hourly_counts — legacy key format: "yyyy-MM-dd-HH"
+                for (hourKey, count) in legacy.hourlyCounts where count > 0 {
+                    let parts = hourKey.split(separator: "-")
+                    guard parts.count == 4, let hour = Int(parts[3]) else { continue }
+                    let date = "\(parts[0])-\(parts[1])-\(parts[2])"
+                    try db.execute(sql: """
+                        INSERT INTO hourly_counts (date, hour, count) VALUES (?, ?, ?)
+                        ON CONFLICT(date, hour) DO UPDATE SET count = count + excluded.count
+                        """, arguments: [date, hour, count])
+                    totalRows += 1
+                }
+                // bigram_iki
+                for (bigram, sum) in legacy.bigramIKISum {
+                    let count = legacy.bigramIKICount[bigram] ?? 0
+                    guard sum > 0, count > 0 else { continue }
+                    try db.execute(sql: """
+                        INSERT INTO bigram_iki (bigram, iki_sum, iki_count) VALUES (?, ?, ?)
+                        ON CONFLICT(bigram) DO UPDATE SET
+                            iki_sum   = iki_sum   + excluded.iki_sum,
+                            iki_count = iki_count + excluded.iki_count
+                        """, arguments: [bigram, sum, count])
+                    totalRows += 1
+                }
+            }
+
+            UserDefaults.standard.set(true, forKey: Self.migrationFlagKey)
+            KeyLens.log("KeyCountStore: migration complete — \(totalRows) rows imported to keylens.db")
+
+        } catch {
+            // Do not set the flag — will retry on next launch
+            KeyLens.log("KeyCountStore: migration error: \(error)")
+        }
+    }
+}
+
+// MARK: - Legacy JSON model (only used during migration)
+
+private struct LegacyCounts: Decodable {
+    var dailyCounts:      [String: [String: Int]] = [:]
+    var dailyBigramCounts: [String: [String: Int]] = [:]
+    var dailyTrigramCounts:[String: [String: Int]] = [:]
+    var dailyAppCounts:   [String: [String: Int]] = [:]
+    var dailyDeviceCounts:[String: [String: Int]] = [:]
+    var hourlyCounts:     [String: Int]           = [:]
+    var bigramIKISum:     [String: Double]        = [:]
+    var bigramIKICount:   [String: Int]           = [:]
+
+    enum CodingKeys: String, CodingKey {
+        case dailyCounts, dailyBigramCounts, dailyTrigramCounts
+        case dailyAppCounts, dailyDeviceCounts
+        case hourlyCounts, bigramIKISum, bigramIKICount
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        dailyCounts       = (try? c.decode([String: [String: Int]].self, forKey: .dailyCounts))       ?? [:]
+        dailyBigramCounts  = (try? c.decode([String: [String: Int]].self, forKey: .dailyBigramCounts))  ?? [:]
+        dailyTrigramCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyTrigramCounts)) ?? [:]
+        dailyAppCounts     = (try? c.decode([String: [String: Int]].self, forKey: .dailyAppCounts))     ?? [:]
+        dailyDeviceCounts  = (try? c.decode([String: [String: Int]].self, forKey: .dailyDeviceCounts))  ?? [:]
+        hourlyCounts   = (try? c.decode([String: Int].self,    forKey: .hourlyCounts))   ?? [:]
+        bigramIKISum   = (try? c.decode([String: Double].self, forKey: .bigramIKISum))   ?? [:]
+        bigramIKICount = (try? c.decode([String: Int].self,    forKey: .bigramIKICount)) ?? [:]
+    }
+}

--- a/Sources/KeyLens/KeyCountStore+SQLite.swift
+++ b/Sources/KeyLens/KeyCountStore+SQLite.swift
@@ -1,0 +1,284 @@
+import Foundation
+import GRDB
+
+// MARK: - In-memory accumulator (flushed to SQLite every 30 seconds)
+// All fields are deltas since the last flush. Protected by KeyCountStore.queue.
+
+struct PendingStore {
+    var dailyKeys:     [String: [String: Int]] = [:]  // date → key → delta
+    var dailyBigrams:  [String: [String: Int]] = [:]  // date → bigram → delta
+    var dailyTrigrams: [String: [String: Int]] = [:]  // date → trigram → delta
+    var dailyApps:     [String: [String: Int]] = [:]  // date → app → delta
+    var dailyDevices:  [String: [String: Int]] = [:]  // date → device → delta
+    var hourly:        [String: [Int: Int]]    = [:]  // date → hour → delta
+    var bigramIKI:     [String: (sum: Double, count: Int)] = [:]
+    var ikiBuckets:    [String: [Int: Int]]    = [:]  // date → bucket → delta
+
+    var isEmpty: Bool {
+        dailyKeys.isEmpty && dailyBigrams.isEmpty && dailyTrigrams.isEmpty &&
+        dailyApps.isEmpty && dailyDevices.isEmpty && hourly.isEmpty &&
+        bigramIKI.isEmpty && ikiBuckets.isEmpty
+    }
+}
+
+// MARK: - IKI bucket constants
+
+extension KeyCountStore {
+    /// Returns the histogram bucket index (0–6) for a given IKI value in ms.
+    /// Buckets: 0=0–50ms, 1=50–100ms, ..., 5=250–300ms, 6=300+ms
+    static func ikiBucket(for ms: Double) -> Int { min(Int(ms / 50.0), 6) }
+    static let ikiBucketLabels = ["0–50", "50–100", "100–150", "150–200", "200–250", "250–300", "300+"]
+}
+
+// MARK: - SQLite setup & flush
+
+extension KeyCountStore {
+
+    static let dbFileName = "keylens.db"
+
+    func setupDatabase() {
+        do {
+            let dir = try FileManager.default
+                .url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+                .appendingPathComponent("KeyLens")
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            let dbPath = dir.appendingPathComponent(Self.dbFileName).path
+
+            let db = try DatabaseQueue(path: dbPath)
+
+            var migrator = DatabaseMigrator()
+            migrator.registerMigration("v1") { db in
+                try db.create(table: "daily_keys", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("key", .text).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "key"])
+                }
+                try db.create(table: "daily_bigrams", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("bigram", .text).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "bigram"])
+                }
+                try db.create(table: "daily_trigrams", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("trigram", .text).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "trigram"])
+                }
+                try db.create(table: "daily_apps", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("app", .text).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "app"])
+                }
+                try db.create(table: "daily_devices", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("device", .text).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "device"])
+                }
+                try db.create(table: "hourly_counts", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("hour", .integer).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "hour"])
+                }
+                try db.create(table: "bigram_iki", ifNotExists: true) { t in
+                    t.primaryKey("bigram", .text)
+                    t.column("iki_sum", .double).notNull().defaults(to: 0)
+                    t.column("iki_count", .integer).notNull().defaults(to: 0)
+                }
+                // IKI histogram: bucket 0=0–50ms … 6=300+ms
+                try db.create(table: "iki_buckets", ifNotExists: true) { t in
+                    t.column("date", .text).notNull()
+                    t.column("bucket", .integer).notNull()
+                    t.column("count", .integer).notNull().defaults(to: 0)
+                    t.primaryKey(["date", "bucket"])
+                }
+            }
+            try migrator.migrate(db)
+
+            dbQueue = db
+            KeyLens.log("KeyCountStore: SQLite ready at \(dbPath)")
+        } catch {
+            KeyLens.log("KeyCountStore: SQLite init failed: \(error)")
+        }
+    }
+
+    func startFlushTimer() {
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 30, repeating: 30)
+        timer.setEventHandler { [weak self] in self?.flushLocked() }
+        timer.resume()
+        flushTimer = timer
+    }
+
+    /// Flush pending deltas to SQLite. Must be called on `queue`.
+    func flushLocked() {
+        guard !pending.isEmpty, let db = dbQueue else { return }
+        let p = pending
+        pending = PendingStore()
+
+        do {
+            try db.write { db in
+                for (date, keys) in p.dailyKeys {
+                    for (key, delta) in keys where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_keys (date, key, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, key) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, key, delta])
+                    }
+                }
+                for (date, bigrams) in p.dailyBigrams {
+                    for (bigram, delta) in bigrams where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_bigrams (date, bigram, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, bigram) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, bigram, delta])
+                    }
+                }
+                for (date, trigrams) in p.dailyTrigrams {
+                    for (trigram, delta) in trigrams where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_trigrams (date, trigram, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, trigram) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, trigram, delta])
+                    }
+                }
+                for (date, apps) in p.dailyApps {
+                    for (app, delta) in apps where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_apps (date, app, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, app) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, app, delta])
+                    }
+                }
+                for (date, devices) in p.dailyDevices {
+                    for (device, delta) in devices where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO daily_devices (date, device, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, device) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, device, delta])
+                    }
+                }
+                for (date, hours) in p.hourly {
+                    for (hour, delta) in hours where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO hourly_counts (date, hour, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, hour) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, hour, delta])
+                    }
+                }
+                for (bigram, (sum, count)) in p.bigramIKI where count > 0 {
+                    try db.execute(sql: """
+                        INSERT INTO bigram_iki (bigram, iki_sum, iki_count) VALUES (?, ?, ?)
+                        ON CONFLICT(bigram) DO UPDATE SET
+                            iki_sum   = iki_sum   + excluded.iki_sum,
+                            iki_count = iki_count + excluded.iki_count
+                        """, arguments: [bigram, sum, count])
+                }
+                for (date, buckets) in p.ikiBuckets {
+                    for (bucket, delta) in buckets where delta > 0 {
+                        try db.execute(sql: """
+                            INSERT INTO iki_buckets (date, bucket, count) VALUES (?, ?, ?)
+                            ON CONFLICT(date, bucket) DO UPDATE SET count = count + excluded.count
+                            """, arguments: [date, bucket, delta])
+                    }
+                }
+            }
+        } catch {
+            pending = mergePending(p, into: pending)
+            KeyLens.log("KeyCountStore: SQLite flush error: \(error)")
+        }
+    }
+
+    /// Synchronous flush — call on app termination to avoid data loss.
+    func flushSync() {
+        queue.sync { flushLocked() }
+    }
+
+    private func mergePending(_ source: PendingStore, into target: PendingStore) -> PendingStore {
+        var r = target
+        for (d, keys)    in source.dailyKeys     { for (k,v) in keys    { r.dailyKeys[d,    default:[:]][k, default:0] += v } }
+        for (d, bigrams) in source.dailyBigrams  { for (b,v) in bigrams { r.dailyBigrams[d, default:[:]][b, default:0] += v } }
+        for (d, tris)    in source.dailyTrigrams { for (t,v) in tris    { r.dailyTrigrams[d,default:[:]][t, default:0] += v } }
+        for (d, apps)    in source.dailyApps     { for (a,v) in apps    { r.dailyApps[d,    default:[:]][a, default:0] += v } }
+        for (d, devs)    in source.dailyDevices  { for (x,v) in devs    { r.dailyDevices[d, default:[:]][x, default:0] += v } }
+        for (d, hrs)     in source.hourly        { for (h,v) in hrs     { r.hourly[d,       default:[:]][h, default:0] += v } }
+        for (bigram, (sum, cnt)) in source.bigramIKI {
+            let e = r.bigramIKI[bigram] ?? (0, 0)
+            r.bigramIKI[bigram] = (e.sum + sum, e.count + cnt)
+        }
+        for (d, bkts) in source.ikiBuckets { for (b,v) in bkts { r.ikiBuckets[d, default:[:]][b, default:0] += v } }
+        return r
+    }
+}
+
+// MARK: - SQL helpers (must be called inside queue.sync)
+
+extension KeyCountStore {
+
+    /// Per-key counts for a date: SQLite + pending merged.
+    func dailyKeyCountsLocked(for date: String) -> [String: Int] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in try Row.fetchAll(db, sql: "SELECT key, count FROM daily_keys WHERE date = ?", arguments: [date]) }) {
+            for row in rows { result[row["key"], default: 0] += (row["count"] as Int) }
+        }
+        for (k, v) in pending.dailyKeys[date, default: [:]] { result[k, default: 0] += v }
+        return result
+    }
+
+    /// Total keystrokes for a date: SQLite + pending merged.
+    func dailyTotalLocked(for date: String) -> Int {
+        var total = 0
+        if let db = dbQueue {
+            total = (try? db.read { db in
+                try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(count),0) FROM daily_keys WHERE date = ?", arguments: [date])
+            }) ?? 0
+        }
+        total += pending.dailyKeys[date, default: [:]].values.reduce(0, +)
+        return total
+    }
+
+    /// All distinct dates that have keystroke data in SQLite.
+    func allDatesLocked() -> [String] {
+        guard let db = dbQueue else { return [] }
+        return (try? db.read { db in
+            try String.fetchAll(db, sql: "SELECT DISTINCT date FROM daily_keys ORDER BY date")
+        }) ?? []
+    }
+}
+
+// MARK: - IKI histogram query
+
+extension KeyCountStore {
+
+    /// IKI histogram entries combining all-time SQLite data + unflushed pending.
+    func ikiHistogramEntries() -> [IKIHistogramEntry] {
+        queue.sync {
+            var buckets = [Int](repeating: 0, count: 7)
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT bucket, SUM(count) as total FROM iki_buckets GROUP BY bucket")
+               }) {
+                for row in rows {
+                    let b: Int = row["bucket"]
+                    if b < 7 { buckets[b] += (row["total"] as Int) }
+                }
+            }
+            for (_, dateBuckets) in pending.ikiBuckets {
+                for (b, v) in dateBuckets where b < 7 { buckets[b] += v }
+            }
+            let total = buckets.reduce(0, +)
+            return Self.ikiBucketLabels.enumerated().map { i, label in
+                IKIHistogramEntry(
+                    bucket: label,
+                    count: buckets[i],
+                    percentage: total > 0 ? Double(buckets[i]) / Double(total) * 100.0 : 0
+                )
+            }
+        }
+    }
+}

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -1,92 +1,70 @@
 import AppKit
 import Foundation
+import GRDB
 import KeyLensCore
 import UserNotifications
 
 // MARK: - Data model
 
-/// All persisted data. startedAt records when tracking began.
-/// 永続化するデータ全体。startedAt でいつから記録を開始したかを保持する
+/// Persisted scalars and small fixed-size maps. Large per-day dictionaries
+/// are stored in keylens.db (see KeyCountStore+SQLite.swift).
+/// 永続化するスカラー値と小規模マップ。大きな日次ディクショナリは keylens.db に移行済み。
 struct CountData: Codable {
     var startedAt: Date
-    var counts: [String: Int]
-    var dailyCounts: [String: [String: Int]]   // "yyyy-MM-dd" -> keyName -> count
+    var counts: [String: Int]                      // all-time per-key cumulative count
     var lastInputTime: Date?
-    var avgIntervalMs: Double                  // Welford 移動平均（単位: ms）
-    var avgIntervalCount: Int                  // 平均の標本数
-    var modifiedCounts: [String: Int]          // "⌘c", "⇧a" など修飾キー+キー組み合わせ
-    var dailyMinIntervalMs: [String: Double]   // "yyyy-MM-dd" -> 当日の最小入力間隔（ms, 1000ms以内のみ）
-    // Daily Welford average interval tracking (Issue #59 Phase 2) — for per-day WPM chart
-    // 日別 Welford 平均間隔（日別 WPM チャート用）
-    var dailyAvgIntervalMs:    [String: Double] // "yyyy-MM-dd" -> daily Welford avg interval (ms)
-    var dailyAvgIntervalCount: [String: Int]    // "yyyy-MM-dd" -> daily Welford sample count
+    var avgIntervalMs: Double                      // Welford moving average (ms)
+    var avgIntervalCount: Int                      // Welford sample count
+    var modifiedCounts: [String: Int]              // "⌘c", "⇧a" modifier+key combos
+    var dailyMinIntervalMs: [String: Double]       // "yyyy-MM-dd" -> daily min IKI (ms, ≤1000ms)
+    // Daily Welford average interval (Issue #59 Phase 2)
+    var dailyAvgIntervalMs:    [String: Double]
+    var dailyAvgIntervalCount: [String: Int]
     // Same-finger bigram tracking (Issue #16)
-    var sameFingerCount: Int                   // Cumulative same-finger consecutive pairs
-    var totalBigramCount: Int                  // Cumulative consecutive pairs (denominator)
-    var dailySameFingerCount: [String: Int]    // "yyyy-MM-dd" -> same-finger pairs that day
-    var dailyTotalBigramCount: [String: Int]   // "yyyy-MM-dd" -> total pairs that day
+    var sameFingerCount: Int
+    var totalBigramCount: Int
+    var dailySameFingerCount:  [String: Int]
+    var dailyTotalBigramCount: [String: Int]
     // Hand alternation tracking (Issue #17)
-    var handAlternationCount: Int              // Cumulative hand-alternating pairs
-    var dailyHandAlternationCount: [String: Int] // "yyyy-MM-dd" -> alternating pairs that day
-    // Hourly keystroke counts (Issue #18) — key: "yyyy-MM-dd-HH", value: total keystrokes
-    // Retention: entries older than 365 days are pruned on load.
-    var hourlyCounts: [String: Int]
-    // Bigram frequency table (Issue #12) — key: "a→s", value: cumulative count
-    var bigramCounts: [String: Int]
-    // Daily bigram frequency — "yyyy-MM-dd" -> pair -> count
-    var dailyBigramCounts: [String: [String: Int]]
-    // Bigram IKI accumulation (Issue #24)
-    var bigramIKISum: [String: Double]   // "a→s" -> cumulative IKI sum (ms)
-    var bigramIKICount: [String: Int]    // "a→s" -> number of IKI samples
-    // Alternation reward accumulation (Issue #25)
-    var alternationRewardScore: Double   // cumulative reward score
-    // High-strain sequence tracking (Issue #28)
-    var highStrainBigramCount: Int               // cumulative high-strain bigrams
-    var dailyHighStrainBigramCount: [String: Int] // "yyyy-MM-dd" -> count
-    var highStrainTrigramCount: Int               // cumulative high-strain trigrams
-    var dailyHighStrainTrigramCount: [String: Int] // "yyyy-MM-dd" -> count
-    // General trigram frequency table (Issue #12)
+    var handAlternationCount: Int
+    var dailyHandAlternationCount: [String: Int]
+    // All-time bigram / trigram frequency (small enough to stay in JSON)
+    var bigramCounts:  [String: Int]
     var trigramCounts: [String: Int]
-    // Daily trigram frequency — "yyyy-MM-dd" -> trigram -> count
-    var dailyTrigramCounts: [String: [String: Int]]
-    // Per-application keystroke counts — appName -> total count
-    var appCounts: [String: Int]
-    // Daily per-application keystroke counts — "yyyy-MM-dd" -> appName -> count
-    var dailyAppCounts: [String: [String: Int]]
-    // Per-device keystroke counts — deviceLabel -> total count
+    // Alternation reward (Issue #25)
+    var alternationRewardScore: Double
+    // High-strain sequence tracking (Issue #28)
+    var highStrainBigramCount: Int
+    var dailyHighStrainBigramCount:  [String: Int]
+    var highStrainTrigramCount: Int
+    var dailyHighStrainTrigramCount: [String: Int]
+    // Per-app / per-device cumulative totals and ergonomic counters
+    var appCounts:    [String: Int]
     var deviceCounts: [String: Int]
-    // Daily per-device keystroke counts — "yyyy-MM-dd" -> deviceLabel -> count
-    var dailyDeviceCounts: [String: [String: Int]]
-    // Per-application bigram tracking for ergonomic score computation
     var appSameFingerCount:      [String: Int]
     var appTotalBigramCount:     [String: Int]
     var appHandAlternationCount: [String: Int]
-    var appHighStrainBigramCount: [String: Int]
-    // Per-device bigram tracking for ergonomic score computation
+    var appHighStrainBigramCount:[String: Int]
     var deviceSameFingerCount:      [String: Int]
     var deviceTotalBigramCount:     [String: Int]
     var deviceHandAlternationCount: [String: Int]
-    var deviceHighStrainBigramCount: [String: Int]
-    // Daily shortcut counts (Issue #66) — "yyyy-MM-dd" -> total modifier+key combos that day
+    var deviceHighStrainBigramCount:[String: Int]
+    // Daily shortcut counts (Issue #66)
     var dailyModifiedCount: [String: Int]
 
     enum CodingKeys: String, CodingKey {
-        case startedAt, counts, dailyCounts
+        case startedAt, counts
         case lastInputTime, avgIntervalMs, avgIntervalCount
         case modifiedCounts, dailyMinIntervalMs
         case dailyAvgIntervalMs, dailyAvgIntervalCount
         case sameFingerCount, totalBigramCount
         case dailySameFingerCount, dailyTotalBigramCount
         case handAlternationCount, dailyHandAlternationCount
-        case hourlyCounts
-        case bigramCounts, dailyBigramCounts
-        case bigramIKISum, bigramIKICount
+        case bigramCounts, trigramCounts
         case alternationRewardScore
         case highStrainBigramCount, dailyHighStrainBigramCount
         case highStrainTrigramCount, dailyHighStrainTrigramCount
-        case trigramCounts, dailyTrigramCounts
-        case appCounts, dailyAppCounts
-        case deviceCounts, dailyDeviceCounts
+        case appCounts, deviceCounts
         case appSameFingerCount, appTotalBigramCount
         case appHandAlternationCount, appHighStrainBigramCount
         case deviceSameFingerCount, deviceTotalBigramCount
@@ -94,86 +72,69 @@ struct CountData: Codable {
         case dailyModifiedCount
     }
 
-    init(startedAt: Date, counts: [String: Int], dailyCounts: [String: [String: Int]]) {
+    init(startedAt: Date, counts: [String: Int]) {
         self.startedAt = startedAt
-        self.counts = counts
-        self.dailyCounts = dailyCounts
-        self.lastInputTime = nil
-        self.avgIntervalMs = 0
-        self.avgIntervalCount = 0
-        self.modifiedCounts = [:]
-        self.dailyMinIntervalMs = [:]
-        self.dailyAvgIntervalMs    = [:]
+        self.counts    = counts
+        self.lastInputTime        = nil
+        self.avgIntervalMs        = 0
+        self.avgIntervalCount     = 0
+        self.modifiedCounts       = [:]
+        self.dailyMinIntervalMs   = [:]
+        self.dailyAvgIntervalMs   = [:]
         self.dailyAvgIntervalCount = [:]
-        self.sameFingerCount = 0
-        self.totalBigramCount = 0
-        self.dailySameFingerCount = [:]
+        self.sameFingerCount      = 0
+        self.totalBigramCount     = 0
+        self.dailySameFingerCount  = [:]
         self.dailyTotalBigramCount = [:]
-        self.handAlternationCount = 0
+        self.handAlternationCount  = 0
         self.dailyHandAlternationCount = [:]
-        self.hourlyCounts = [:]
-        self.bigramCounts = [:]
-        self.dailyBigramCounts = [:]
-        self.bigramIKISum = [:]
-        self.bigramIKICount = [:]
+        self.bigramCounts  = [:]
+        self.trigramCounts = [:]
         self.alternationRewardScore = 0
-        self.highStrainBigramCount = 0
-        self.dailyHighStrainBigramCount = [:]
+        self.highStrainBigramCount  = 0
+        self.dailyHighStrainBigramCount  = [:]
         self.highStrainTrigramCount = 0
         self.dailyHighStrainTrigramCount = [:]
-        self.trigramCounts = [:]
-        self.dailyTrigramCounts = [:]
-        self.appCounts = [:]
-        self.dailyAppCounts = [:]
+        self.appCounts    = [:]
         self.deviceCounts = [:]
-        self.dailyDeviceCounts = [:]
-        self.appSameFingerCount = [:]
-        self.appTotalBigramCount = [:]
+        self.appSameFingerCount      = [:]
+        self.appTotalBigramCount     = [:]
         self.appHandAlternationCount = [:]
         self.appHighStrainBigramCount = [:]
-        self.deviceSameFingerCount = [:]
-        self.deviceTotalBigramCount = [:]
+        self.deviceSameFingerCount      = [:]
+        self.deviceTotalBigramCount     = [:]
         self.deviceHandAlternationCount = [:]
         self.deviceHighStrainBigramCount = [:]
         self.dailyModifiedCount = [:]
     }
 
-    /// Migration from legacy formats and backward-compatible decode for new fields.
-    /// 旧フォーマットからのマイグレーション。新フィールドはデフォルト値で開始。
+    /// Backward-compatible decode — new fields default to zero/empty.
     init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         startedAt = try c.decode(Date.self, forKey: .startedAt)
         counts    = try c.decode([String: Int].self, forKey: .counts)
-        dailyCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyCounts)) ?? [:]
-        lastInputTime   = try? c.decode(Date.self, forKey: .lastInputTime)
-        avgIntervalMs   = (try? c.decode(Double.self, forKey: .avgIntervalMs)) ?? 0
-        avgIntervalCount = (try? c.decode(Int.self, forKey: .avgIntervalCount)) ?? 0
-        modifiedCounts  = (try? c.decode([String: Int].self, forKey: .modifiedCounts)) ?? [:]
-        dailyMinIntervalMs    = (try? c.decode([String: Double].self, forKey: .dailyMinIntervalMs)) ?? [:]
+        lastInputTime    = try? c.decode(Date.self,   forKey: .lastInputTime)
+        avgIntervalMs    = (try? c.decode(Double.self, forKey: .avgIntervalMs))    ?? 0
+        avgIntervalCount = (try? c.decode(Int.self,    forKey: .avgIntervalCount)) ?? 0
+        modifiedCounts   = (try? c.decode([String: Int].self, forKey: .modifiedCounts)) ?? [:]
+        dailyMinIntervalMs    = (try? c.decode([String: Double].self, forKey: .dailyMinIntervalMs))    ?? [:]
         dailyAvgIntervalMs    = (try? c.decode([String: Double].self, forKey: .dailyAvgIntervalMs))    ?? [:]
         dailyAvgIntervalCount = (try? c.decode([String: Int].self,    forKey: .dailyAvgIntervalCount)) ?? [:]
         sameFingerCount  = (try? c.decode(Int.self, forKey: .sameFingerCount))  ?? 0
         totalBigramCount = (try? c.decode(Int.self, forKey: .totalBigramCount)) ?? 0
         dailySameFingerCount  = (try? c.decode([String: Int].self, forKey: .dailySameFingerCount))  ?? [:]
         dailyTotalBigramCount = (try? c.decode([String: Int].self, forKey: .dailyTotalBigramCount)) ?? [:]
-        handAlternationCount      = (try? c.decode(Int.self, forKey: .handAlternationCount))          ?? 0
-        dailyHandAlternationCount = (try? c.decode([String: Int].self, forKey: .dailyHandAlternationCount)) ?? [:]
-        hourlyCounts = (try? c.decode([String: Int].self, forKey: .hourlyCounts)) ?? [:]
-        bigramCounts = (try? c.decode([String: Int].self, forKey: .bigramCounts)) ?? [:]
-        dailyBigramCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyBigramCounts)) ?? [:]
-        bigramIKISum   = (try? c.decode([String: Double].self, forKey: .bigramIKISum))  ?? [:]
-        bigramIKICount = (try? c.decode([String: Int].self,    forKey: .bigramIKICount)) ?? [:]
-        alternationRewardScore = (try? c.decode(Double.self, forKey: .alternationRewardScore)) ?? 0
-        highStrainBigramCount        = (try? c.decode(Int.self,            forKey: .highStrainBigramCount))        ?? 0
-        dailyHighStrainBigramCount   = (try? c.decode([String: Int].self,  forKey: .dailyHighStrainBigramCount))   ?? [:]
-        highStrainTrigramCount       = (try? c.decode(Int.self,            forKey: .highStrainTrigramCount))       ?? 0
-        dailyHighStrainTrigramCount  = (try? c.decode([String: Int].self,  forKey: .dailyHighStrainTrigramCount))  ?? [:]
-        trigramCounts      = (try? c.decode([String: Int].self,           forKey: .trigramCounts))      ?? [:]
-        dailyTrigramCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyTrigramCounts)) ?? [:]
-        appCounts      = (try? c.decode([String: Int].self,            forKey: .appCounts))      ?? [:]
-        dailyAppCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyAppCounts)) ?? [:]
-        deviceCounts      = (try? c.decode([String: Int].self,            forKey: .deviceCounts))      ?? [:]
-        dailyDeviceCounts = (try? c.decode([String: [String: Int]].self, forKey: .dailyDeviceCounts)) ?? [:]
+        handAlternationCount      = (try? c.decode(Int.self,            forKey: .handAlternationCount))      ?? 0
+        dailyHandAlternationCount = (try? c.decode([String: Int].self,  forKey: .dailyHandAlternationCount)) ?? [:]
+        bigramCounts  = (try? c.decode([String: Int].self, forKey: .bigramCounts))  ?? [:]
+        trigramCounts = (try? c.decode([String: Int].self, forKey: .trigramCounts)) ?? [:]
+        alternationRewardScore       = (try? c.decode(Double.self,          forKey: .alternationRewardScore))       ?? 0
+        highStrainBigramCount        = (try? c.decode(Int.self,             forKey: .highStrainBigramCount))        ?? 0
+        dailyHighStrainBigramCount   = (try? c.decode([String: Int].self,   forKey: .dailyHighStrainBigramCount))   ?? [:]
+        highStrainTrigramCount       = (try? c.decode(Int.self,             forKey: .highStrainTrigramCount))       ?? 0
+        dailyHighStrainTrigramCount  = (try? c.decode([String: Int].self,   forKey: .dailyHighStrainTrigramCount))  ?? [:]
+        appCounts    = (try? c.decode([String: Int].self, forKey: .appCounts))    ?? [:]
+        deviceCounts = (try? c.decode([String: Int].self, forKey: .deviceCounts)) ?? [:]
         appSameFingerCount       = (try? c.decode([String: Int].self, forKey: .appSameFingerCount))       ?? [:]
         appTotalBigramCount      = (try? c.decode([String: Int].self, forKey: .appTotalBigramCount))      ?? [:]
         appHandAlternationCount  = (try? c.decode([String: Int].self, forKey: .appHandAlternationCount))  ?? [:]
@@ -188,29 +149,36 @@ struct CountData: Codable {
 
 // MARK: - Store
 
-/// Singleton that manages keystroke counts and persists them to a JSON file.
-/// キーごとのカウントを管理し、JSONファイルに永続化するシングルトン
+/// Singleton that manages keystroke counts.
+/// Scalars are persisted to counts.json; large per-day data is persisted to keylens.db.
+/// キーストロークカウントを管理するシングルトン。
+/// スカラー値は counts.json、大きな日次データは keylens.db に永続化する。
 final class KeyCountStore {
     static let shared = KeyCountStore()
 
-    // Internal so extension files in this target can access them.
     var store: CountData
     let queue = DispatchQueue(label: "com.keycounter.store")
 
     let saveURL: URL
     private var saveWorkItem: DispatchWorkItem?
 
-    // In-memory only: last key pressed, used for same-finger bigram detection.
+    // SQLite backing store (set up in setupDatabase())
+    var dbQueue: DatabaseQueue?
+    var pending = PendingStore()
+    var flushTimer: DispatchSourceTimer?
+
+    // Today count cache — avoids SQLite reads in the hot path.
+    // Updated in increment(); reset when the calendar date changes.
+    private var _todayCount: Int = 0
+    private var _todayCacheDate: String = ""
+
+    // In-memory rolling state (not persisted)
     private var lastKeyName: String?
-    // In-memory only: second-to-last key pressed, used for trigram rolling window (Issue #12).
     private var secondLastKeyName: String?
-    // In-memory only: whether the previous bigram was high-strain (Issue #28).
     private var lastBigramWasHighStrain: Bool = false
-    // In-memory only: consecutive hand-alternating pair count for streak detection (Issue #25).
     private var alternationStreak: Int = 0
 
     // In-memory ring buffer: last 20 IKI values (key + interval ms, ≤1000ms only).
-    // Readable from extension files; writable only from this file.
     private(set) var recentIKIs: [(key: String, iki: Double)] = []
     private let recentIKICapacity = 20
 
@@ -220,8 +188,20 @@ final class KeyCountStore {
             .appendingPathComponent("KeyLens")
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         saveURL = dir.appendingPathComponent("counts.json")
-        store = CountData(startedAt: Date(), counts: [:], dailyCounts: [:])
-        load()
+        store = CountData(startedAt: Date(), counts: [:])
+        setupDatabase()      // creates keylens.db and schema
+        migrateIfNeeded()    // one-time import from counts.json
+        load()               // load slim JSON scalars
+        // Prime today count cache from SQLite
+        let today = todayKey
+        _todayCacheDate = today
+        if let db = dbQueue {
+            _todayCount = (try? db.read { db in
+                try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(count),0) FROM daily_keys WHERE date = ?",
+                                 arguments: [today])
+            }) ?? 0
+        }
+        startFlushTimer()
     }
 
     /// Notification interval (persisted in UserDefaults, default 1000).
@@ -230,88 +210,97 @@ final class KeyCountStore {
         set { UserDefaults.standard.set(newValue, forKey: "milestoneInterval") }
     }
 
-    // MARK: - Date helpers (internal for use by extension files)
+    // MARK: - Date helpers
 
     static let dayFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy-MM-dd"
-        return f
-    }()
-
-    static let hourFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd-HH"
+        f.locale = Locale(identifier: "en_US_POSIX")
         return f
     }()
 
     var todayKey: String { Self.dayFormatter.string(from: Date()) }
-    var currentHourKey: String { Self.hourFormatter.string(from: Date()) }
 
     // MARK: - Mutation
 
     /// Increment count by 1. Returns (newCount, isMilestone).
-    /// カウントを1増やす。milestoneInterval の倍数に達したら milestone = true を返す
     func increment(key: String, at timestamp: Date = Date(), appName: String? = nil) -> (count: Int, milestone: Bool) {
         let today = todayKey
-        let hourKey = currentHourKey
+        let hour  = Calendar.current.component(.hour, from: timestamp)
         let deviceName = LayoutRegistry.shared.currentDeviceLabel
+
         let count: Int = queue.sync {
+            // All-time per-key count (stays in JSON)
             store.counts[key, default: 0] += 1
-            store.dailyCounts[today, default: [:]][key, default: 0] += 1
-            // Hourly count (Issue #18)
-            store.hourlyCounts[hourKey, default: 0] += 1
-            // Per-application count
+
+            // Per-day key count → SQLite pending
+            pending.dailyKeys[today, default: [:]][key, default: 0] += 1
+            // Hourly count → SQLite pending
+            pending.hourly[today, default: [:]][hour, default: 0] += 1
+            // Per-app → SQLite pending
             if let app = appName {
                 store.appCounts[app, default: 0] += 1
-                store.dailyAppCounts[today, default: [:]][app, default: 0] += 1
+                pending.dailyApps[today, default: [:]][app, default: 0] += 1
             }
+            // Per-device → SQLite pending
             store.deviceCounts[deviceName, default: 0] += 1
-            store.dailyDeviceCounts[today, default: [:]][deviceName, default: 0] += 1
+            pending.dailyDevices[today, default: [:]][deviceName, default: 0] += 1
 
-            // Save previous timestamp before updating — needed for per-bigram IKI below.
+            // Update today count cache
+            if _todayCacheDate != today {
+                _todayCacheDate = today
+                _todayCount = dailyTotalLocked(for: today)
+            }
+            _todayCount += 1
+
             let prevInputTime = store.lastInputTime
 
-            // Welford's online algorithm: only intervals ≤1000ms contribute to average and min.
+            // Welford IKI update (≤1000ms only)
             if let last = store.lastInputTime {
                 let intervalMs = timestamp.timeIntervalSince(last) * 1000
                 if intervalMs <= 1000 {
-                    // Global Welford update
+                    // Global Welford
                     store.avgIntervalCount += 1
                     store.avgIntervalMs += (intervalMs - store.avgIntervalMs) / Double(store.avgIntervalCount)
-                    // Daily min interval
+                    // Daily min
                     if intervalMs < (store.dailyMinIntervalMs[today] ?? Double.infinity) {
                         store.dailyMinIntervalMs[today] = intervalMs
                     }
-                    // Daily Welford update (Issue #59 Phase 2)
+                    // Daily Welford (Issue #59)
                     let dc = store.dailyAvgIntervalCount[today, default: 0] + 1
                     store.dailyAvgIntervalCount[today] = dc
                     let prevAvg = store.dailyAvgIntervalMs[today, default: 0.0]
                     store.dailyAvgIntervalMs[today] = prevAvg + (intervalMs - prevAvg) / Double(dc)
-                    // Live IKI ring buffer (capped at recentIKICapacity)
+                    // Live ring buffer
                     recentIKIs.append((key: key, iki: intervalMs))
                     if recentIKIs.count > recentIKICapacity { recentIKIs.removeFirst() }
+                    // IKI histogram bucket → SQLite pending
+                    let bucket = KeyCountStore.ikiBucket(for: intervalMs)
+                    pending.ikiBuckets[today, default: [:]][bucket, default: 0] += 1
                 }
             } else {
-                // First keystroke in session — no interval yet; record as anchor (iki = 0).
+                // First keystroke in session — anchor (iki = 0)
                 recentIKIs.append((key: key, iki: 0))
                 if recentIKIs.count > recentIKICapacity { recentIKIs.removeFirst() }
             }
             store.lastInputTime = timestamp
 
-            // Same-finger bigram detection (Issue #16)
+            // Same-finger / alternation / bigram ergonomics
             let layout = LayoutRegistry.shared
             if let prev = lastKeyName,
                let prevFinger = layout.current.finger(for: prev),
                let prevHand   = layout.hand(for: prev),
                let curFinger  = layout.current.finger(for: key),
                let curHand    = layout.hand(for: key) {
+
                 store.totalBigramCount += 1
                 store.dailyTotalBigramCount[today, default: 0] += 1
+
                 if prevFinger == curFinger && prevHand == curHand {
                     store.sameFingerCount += 1
                     store.dailySameFingerCount[today, default: 0] += 1
                 }
-                // Hand alternation detection (Issue #17) + reward accumulation (Issue #25)
+
                 if prevHand != curHand {
                     store.handAlternationCount += 1
                     store.dailyHandAlternationCount[today, default: 0] += 1
@@ -321,19 +310,22 @@ final class KeyCountStore {
                 } else {
                     alternationStreak = 0
                 }
-                // Raw bigram pair frequency (Issue #12)
+
+                // Bigram frequency (all-time stays in JSON; daily → SQLite)
                 let pair = Bigram(from: prev, to: key).key
                 store.bigramCounts[pair, default: 0] += 1
-                store.dailyBigramCounts[today, default: [:]][pair, default: 0] += 1
-                // Bigram IKI accumulation (Issue #24)
+                pending.dailyBigrams[today, default: [:]][pair, default: 0] += 1
+
+                // Bigram IKI → SQLite pending (Issue #24)
                 if let prevTime = prevInputTime {
                     let iki = timestamp.timeIntervalSince(prevTime) * 1000
                     if iki <= 1000 {
-                        store.bigramIKISum[pair, default: 0]   += iki
-                        store.bigramIKICount[pair, default: 0] += 1
+                        let existing = pending.bigramIKI[pair] ?? (sum: 0, count: 0)
+                        pending.bigramIKI[pair] = (sum: existing.sum + iki, count: existing.count + 1)
                     }
                 }
-                // High-strain sequence detection (Issue #28)
+
+                // High-strain detection (Issue #28)
                 let highStrain = layout.highStrainDetector.isHighStrain(from: prev, to: key, layout: layout)
                 if highStrain {
                     store.highStrainBigramCount += 1
@@ -344,43 +336,36 @@ final class KeyCountStore {
                     }
                 }
                 lastBigramWasHighStrain = highStrain
-                // Per-app bigram ergonomic tracking
+
+                // Per-app bigram ergonomics
                 if let app = appName {
                     store.appTotalBigramCount[app, default: 0] += 1
                     if prevFinger == curFinger && prevHand == curHand {
                         store.appSameFingerCount[app, default: 0] += 1
                     }
-                    if prevHand != curHand {
-                        store.appHandAlternationCount[app, default: 0] += 1
-                    }
-                    if highStrain {
-                        store.appHighStrainBigramCount[app, default: 0] += 1
-                    }
+                    if prevHand != curHand { store.appHandAlternationCount[app, default: 0] += 1 }
+                    if highStrain          { store.appHighStrainBigramCount[app, default: 0] += 1 }
                 }
+                // Per-device bigram ergonomics
                 store.deviceTotalBigramCount[deviceName, default: 0] += 1
                 if prevFinger == curFinger && prevHand == curHand {
                     store.deviceSameFingerCount[deviceName, default: 0] += 1
                 }
-                if prevHand != curHand {
-                    store.deviceHandAlternationCount[deviceName, default: 0] += 1
-                }
-                if highStrain {
-                    store.deviceHighStrainBigramCount[deviceName, default: 0] += 1
-                }
-                // General trigram frequency (Issue #12) — 3-key rolling window.
+                if prevHand != curHand { store.deviceHandAlternationCount[deviceName, default: 0] += 1 }
+                if highStrain          { store.deviceHighStrainBigramCount[deviceName, default: 0] += 1 }
+
+                // Trigram frequency (all-time stays in JSON; daily → SQLite) (Issue #12)
                 if let prev2 = secondLastKeyName {
                     let trigram = "\(prev2)→\(prev)→\(key)"
                     store.trigramCounts[trigram, default: 0] += 1
-                    store.dailyTrigramCounts[today, default: [:]][trigram, default: 0] += 1
+                    pending.dailyTrigrams[today, default: [:]][trigram, default: 0] += 1
                 }
                 secondLastKeyName = prev
             } else {
-                // Chain broken (unmapped key / mouse click) — reset trigram window.
                 secondLastKeyName = nil
             }
             lastKeyName = key
 
-            // Daily goal notification check (Issue #69)
             checkGoalNotificationLocked(todayStr: today)
 
             return store.counts[key, default: 0]
@@ -404,30 +389,46 @@ final class KeyCountStore {
         queue.sync { store.counts.values.reduce(0, +) }
     }
 
-    /// Date tracking began.
     var startedAt: Date {
         queue.sync { store.startedAt }
     }
 
-    /// Reload data from disk — call after externally replacing counts.json.
+    /// Reload JSON scalars from disk; resets pending and rolling state.
     func reload() {
         queue.sync {
             load()
+            pending = PendingStore()
             lastKeyName = nil
             secondLastKeyName = nil
             alternationStreak = 0
             lastBigramWasHighStrain = false
+            // Re-prime today cache
+            _todayCacheDate = todayKey
+            _todayCount = dailyTotalLocked(for: _todayCacheDate)
         }
     }
 
-    /// Reset all counts and start date to now.
+    /// Reset all counts to zero.
     func reset() {
         queue.sync {
-            store = CountData(startedAt: Date(), counts: [:], dailyCounts: [:])
+            store = CountData(startedAt: Date(), counts: [:])
+            pending = PendingStore()
             lastKeyName = nil
             secondLastKeyName = nil
             alternationStreak = 0
             lastBigramWasHighStrain = false
+            _todayCount = 0
+            _todayCacheDate = todayKey
+            // Clear SQLite tables
+            if let db = dbQueue {
+                try? db.write { db in
+                    for table in ["daily_keys","daily_bigrams","daily_trigrams",
+                                  "daily_apps","daily_devices","hourly_counts",
+                                  "bigram_iki","iki_buckets"] {
+                        try db.execute(sql: "DELETE FROM \(table)")
+                    }
+                }
+            }
         }
         scheduleSave()
     }
@@ -437,21 +438,39 @@ final class KeyCountStore {
     private static let dailyGoalKey    = "dailyGoalCount"
     private static let goalNotifiedKey = "goalNotifiedDate"
 
-    /// Daily keystroke goal. 0 = off. Persisted in UserDefaults.
     var dailyGoal: Int {
         get { UserDefaults.standard.integer(forKey: Self.dailyGoalKey) }
         set { UserDefaults.standard.set(newValue, forKey: Self.dailyGoalKey) }
     }
 
-    /// Inner streak calculation — must be called inside queue.sync.
+    /// Compute consecutive-day streak using a single SQL query.
+    /// Must be called inside queue.sync.
     private func streakLocked(goal: Int) -> Int {
-        var streak = 0
+        guard let db = dbQueue else { return 0 }
         let cal = Calendar.current
+        let cutoffDate = cal.date(byAdding: .day, value: -365, to: Date()) ?? Date()
+        let cutoff = Self.dayFormatter.string(from: cutoffDate)
+
+        // Load all daily totals in one query
+        var totals: [String: Int] = [:]
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: """
+                SELECT date, SUM(count) as total FROM daily_keys
+                WHERE date >= ? GROUP BY date
+                """, arguments: [cutoff])
+        }) {
+            for row in rows { totals[row["date"]] = (row["total"] as Int) }
+        }
+        // Merge pending
+        for (date, keys) in pending.dailyKeys where date >= cutoff {
+            totals[date, default: 0] += keys.values.reduce(0, +)
+        }
+
+        var streak = 0
         var date = Date()
         for _ in 0..<365 {
             let key = Self.dayFormatter.string(from: date)
-            let count = store.dailyCounts[key]?.values.reduce(0, +) ?? 0
-            if count >= goal {
+            if (totals[key] ?? 0) >= goal {
                 streak += 1
                 guard let prev = cal.date(byAdding: .day, value: -1, to: date) else { break }
                 date = prev
@@ -462,21 +481,20 @@ final class KeyCountStore {
         return streak
     }
 
-    /// Current streak: consecutive days (including today if goal met) where daily total >= dailyGoal.
     func currentStreak() -> Int {
         let goal = dailyGoal
         guard goal > 0 else { return 0 }
         return queue.sync { streakLocked(goal: goal) }
     }
 
-    /// Fires a one-per-day notification when today's goal is first crossed. Called inside queue.sync.
+    /// Fires a one-per-day notification when today's goal is first crossed.
+    /// Must be called inside queue.sync.
     private func checkGoalNotificationLocked(todayStr: String) {
         let goal = dailyGoal
         guard goal > 0 else { return }
         let notified = UserDefaults.standard.string(forKey: Self.goalNotifiedKey)
         guard notified != todayStr else { return }
-        let todayTotal = store.dailyCounts[todayStr]?.values.reduce(0, +) ?? 0
-        guard todayTotal >= goal else { return }
+        guard _todayCount >= goal else { return }
         UserDefaults.standard.set(todayStr, forKey: Self.goalNotifiedKey)
         let streak = streakLocked(goal: goal)
         DispatchQueue.main.async {
@@ -493,10 +511,9 @@ final class KeyCountStore {
         }
     }
 
-    // MARK: - Persistence
+    // MARK: - Persistence (JSON scalars)
 
-    /// Debounces disk writes: schedules a save 2 seconds after the last call.
-    /// 2秒以内の連続呼び出しをまとめて1回の書き込みに集約する
+    /// Debounces JSON scalar writes: schedules a save 2 seconds after the last call.
     private func scheduleSave() {
         saveWorkItem?.cancel()
         let item = DispatchWorkItem { [weak self] in self?.save() }
@@ -515,12 +532,7 @@ final class KeyCountStore {
         guard let data = try? Data(contentsOf: saveURL) else { return }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        if var decoded = try? decoder.decode(CountData.self, from: data) {
-            // Retention policy (Issue #18): prune hourlyCounts entries older than 365 days.
-            if let cutoffDate = Calendar.current.date(byAdding: .day, value: -365, to: Date()) {
-                let cutoff = Self.dayFormatter.string(from: cutoffDate)
-                decoded.hourlyCounts = decoded.hourlyCounts.filter { $0.key.prefix(10) >= cutoff }
-            }
+        if let decoded = try? decoder.decode(CountData.self, from: data) {
             store = decoded
         }
     }


### PR DESCRIPTION
## Summary

- Moves all unbounded-growth per-day dictionaries from `counts.json` into `keylens.db` (GRDB/SQLite)
- `CountData` is slimmed to scalars only (~200 KB constant); eliminates the ~67 MB/year JSON growth problem
- Hot path (`increment()`) unchanged in speed — writes to in-memory `PendingStore`, flushed in background every 30s (same pattern as `MouseStore`)
- One-time automatic migration of existing `counts.json` data on first launch (no user action needed; original file kept as backup)
- Adds `iki_buckets` table and `IKIHistogramEntry` type, unblocking issue #102 (IKI histogram)

## New files

| File | Purpose |
|---|---|
| `KeyCountStore+SQLite.swift` | `PendingStore`, GRDB schema (8 tables), flush timer, SQL helpers |
| `KeyCountStore+Migration.swift` | One-time `counts.json` → `keylens.db` importer |

## SQLite tables added to `keylens.db`

`daily_keys`, `daily_bigrams`, `daily_trigrams`, `daily_apps`, `daily_devices`, `hourly_counts`, `bigram_iki`, `iki_buckets`

## Test plan

- [ ] First launch after update: check log for `"migration complete — N rows imported"`
- [ ] Charts window opens and all tabs show correct historical data
- [ ] Menu bar today count is accurate
- [ ] App quit / relaunch preserves today's keystrokes
- [ ] `exportSQLite` produces a valid `.db` file with all 8 tables populated
- [ ] `exportDailyCSV` produces complete CSV with historical data

Closes #34