### PR TITLE
feat: IKI distribution histogram (Close #102)

### DIFF
--- a/Sources/KeyLens/Charts+ActivityTab.swift
+++ b/Sources/KeyLens/Charts+ActivityTab.swift
@@ -9,6 +9,7 @@ extension ChartsView {
             VStack(alignment: .leading, spacing: 40) {
                 chartSection(L10n.shared.chartTitleTypingSpeed, helpText: L10n.shared.helpTypingSpeed) { dailyWPMChart }
                 chartSection(L10n.shared.chartTitleBackspaceRate, helpText: L10n.shared.helpBackspaceRate) { dailyAccuracyChart }
+                chartSection(L10n.shared.chartTitleIKIHistogram, helpText: L10n.shared.helpIKIHistogram) { ikiHistogramChart }
                 chartSection("Hourly Distribution", helpText: L10n.shared.helpHourlyDistribution) { hourlyDistributionChart }
                 chartSection("Daily Totals", helpText: L10n.shared.helpDailyTotals) { dailyTotalsChart }
                 chartSection("Monthly Totals", helpText: L10n.shared.helpMonthlyTotals) { monthlyTotalsChart }
@@ -136,7 +137,7 @@ extension ChartsView {
     }
 
     /// 24-bar chart showing aggregate keystroke count by hour of day.
-    /// 時刻（0〜23時）別の累積打鍵数棒グラフ。
+    /// 時刻 (0〜23時) 別の累積打鍵数棒グラフ。
     @ViewBuilder
     var hourlyDistributionChart: some View {
         let dist = model.hourlyDistribution
@@ -162,8 +163,53 @@ extension ChartsView {
         }
     }
 
+    /// Bar chart showing the distribution of inter-keystroke intervals (IKI) across all recorded keystrokes.
+    /// 全打鍵データのIKI分布ヒストグラム (Issue #102)。
+    @ViewBuilder
+    var ikiHistogramChart: some View {
+        let entries = model.ikiHistogram
+        if entries.isEmpty || entries.allSatisfy({ $0.count == 0 }) {
+            emptyState
+        } else {
+            Chart(entries) { item in
+                BarMark(
+                    x: .value("IKI", item.bucket),
+                    y: .value("Count", item.count)
+                )
+                .foregroundStyle(ikiHistogramColor(for: item.bucket))
+                .cornerRadius(3)
+                .annotation(position: .top, spacing: 3) {
+                    if item.count > 0 {
+                        Text(String(format: "%.0f%%", item.percentage))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks { value in
+                    AxisValueLabel {
+                        if let s = value.as(String.self) {
+                            Text(s).font(.caption2)
+                        }
+                    }
+                    AxisGridLine()
+                }
+            }
+            .frame(height: 180)
+        }
+    }
+
+    private func ikiHistogramColor(for bucket: String) -> Color {
+        switch bucket {
+        case "0–50", "50–100":   return .green.opacity(0.8)
+        case "100–150", "150–200": return .orange.opacity(0.75)
+        default:                   return .red.opacity(0.7)
+        }
+    }
+
     /// Bar chart of total keystrokes per calendar month (last 12 months).
-    /// 月別打鍵数合計の棒グラフ（直近12ヶ月）。
+    /// 月別打鍵数合計の棒グラフ (直近12ヶ月)。
     @ViewBuilder
     var monthlyTotalsChart: some View {
         let entries = Array(model.monthlyTotals.suffix(12))

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -163,4 +163,3 @@ struct IKIHistogramEntry: Identifiable {
     let count: Int          // total keystrokes whose IKI fell in this bucket
     let percentage: Double  // count / total * 100
 }
-

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -46,6 +46,9 @@ final class ChartDataModel: ObservableObject {
     // Live IKI ring buffer — refreshed every 0.5s by a timer in ChartsWindowController.
     // リアルタイムIKIリングバッファ（ChartsWindowControllerのタイマーで0.5秒ごとに更新）。
     @Published var recentIKIEntries:     [RecentIKIEntry]       = []
+    // Issue #102: IKI histogram — all-time bucket distribution
+    // 全打鍵データのIKI分布（バケット別）。
+    @Published var ikiHistogram:         [IKIHistogramEntry]    = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -106,6 +109,8 @@ final class ChartDataModel: ObservableObject {
         dailyWPM = store.dailyWPM().map(DailyWPMEntry.init)
         // Issue #65: daily backspace rate
         dailyAccuracy = store.dailyBackspaceRates().map(DailyAccuracyEntry.init)
+        // Issue #102: IKI histogram
+        ikiHistogram = store.ikiHistogramEntries()
     }
 
     /// Lightweight refresh — reads only the live IKI ring buffer. Called by the 0.5s timer.

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -500,8 +500,19 @@ final class L10n {
 
     var helpRecentIKI: String {
         ja(
-            "直近20打鍵のキー間隔（IKI: Inter-Keystroke Interval）をリアルタイムで表示します。緑＝高速（<150ms）、黄＝中速、赤＝低速（>400ms）。チャートウィンドウを開いた状態でタイピングすると更新されます。",
+            "直近20打鍵のキー間隔 (IKI: Inter-Keystroke Interval) をリアルタイムで表示します。緑＝高速 (<150ms)、黄＝中速、赤＝低速 (>400ms)。チャートウィンドウを開いた状態でタイピングすると更新されます。",
             en: "Real-time inter-keystroke intervals (IKI) for the last 20 keystrokes. Green = fast (<150ms), yellow = medium, red = slow (>400ms). Type with this window open to see it update."
+        )
+    }
+
+    var chartTitleIKIHistogram: String {
+        ja("IKI分布ヒストグラム", en: "IKI Distribution Histogram")
+    }
+
+    var helpIKIHistogram: String {
+        ja(
+            "全打鍵データのキー間隔 (IKI) 分布を50ms刻みのバケットで表示します。緑＝高速 (0–100ms)、橙＝中速、赤＝低速 (300ms+)。タイピングリズムの全体的な傾向を把握できます。",
+            en: "Distribution of inter-keystroke intervals (IKI) across all recorded keystrokes, grouped in 50ms buckets. Green = fast (0–100ms), orange = medium, red = slow (300ms+). Shows your overall typing rhythm profile."
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds all-time IKI histogram to the Activity tab, after the Backspace Rate chart
- Reads from the `iki_buckets` SQLite table (populated by the migration in #34)
- Color-coded bars: green = fast (0–100ms), orange = medium, red = slow (≥200ms); percentage labels above each bar

## Implementation
- `IKIHistogramEntry` struct added to `ChartsDataTypes.swift`
- `ChartDataModel.ikiHistogram` published property, populated in `reload()` via `ikiHistogramEntries()` (already in `KeyCountStore+SQLite.swift`)
- `ikiHistogramChart` view + `activityTab` wiring in `Charts+ActivityTab.swift`
- L10n strings added (EN + JA) for title and help popover

## Test plan
- [x] Build succeeds (`./build.sh --install`)
- [ ] Open Charts window → Activity tab; chart renders with 7 bars
- [ ] Bars show correct percentages from historical SQLite data