### PR TITLE
feat: show slowest bigrams by avg IKI in Ergonomics tab (#103)

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -8,10 +8,34 @@ extension ChartsView {
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
                 chartSection("Top 20 Bigrams", helpText: L10n.shared.helpBigrams, showSort: true) { bigramChart }
+                chartSection(L10n.shared.slowBigramsTitle, helpText: L10n.shared.helpSlowBigrams) { slowBigramChart }
                 chartSection("Ergonomic Learning Curve", helpText: L10n.shared.helpLearningCurve) { learningCurveChart }
                 chartSection("Layout Comparison", helpText: L10n.shared.helpLayoutComparison) { layoutComparisonSection }
             }
             .padding(24)
+        }
+    }
+
+    @ViewBuilder
+    var slowBigramChart: some View {
+        if model.slowBigrams.isEmpty {
+            Text(L10n.shared.slowBigramsNoData)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+        } else {
+            let bigramOrder = model.slowBigrams.map(\.bigram)
+            Chart(model.slowBigrams) { item in
+                BarMark(
+                    x: .value("Avg IKI (ms)", item.avgIKI),
+                    y: .value("Bigram", item.bigram)
+                )
+                .foregroundStyle(Color.orange.opacity(0.8))
+                .cornerRadius(3)
+            }
+            .chartYScale(domain: bigramOrder)
+            .chartXAxisLabel("ms", alignment: .trailing)
+            .chartLegend(.hidden)
+            .frame(height: CGFloat(model.slowBigrams.count * 26 + 24))
         }
     }
 

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -163,3 +163,10 @@ struct IKIHistogramEntry: Identifiable {
     let count: Int          // total keystrokes whose IKI fell in this bucket
     let percentage: Double  // count / total * 100
 }
+
+struct SlowBigramEntry: Identifiable {
+    let id: String          // bigram key e.g. "t→h"
+    let bigram: String
+    let avgIKI: Double      // average inter-key interval in ms
+    init(_ t: (bigram: String, avgIKI: Double)) { id = t.bigram; bigram = t.bigram; avgIKI = t.avgIKI }
+}

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -49,6 +49,8 @@ final class ChartDataModel: ObservableObject {
     // Issue #102: IKI histogram — all-time bucket distribution
     // 全打鍵データのIKI分布（バケット別）。
     @Published var ikiHistogram:         [IKIHistogramEntry]    = []
+    // Issue #103: slowest bigrams by average IKI
+    @Published var slowBigrams:          [SlowBigramEntry]      = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -111,6 +113,8 @@ final class ChartDataModel: ObservableObject {
         dailyAccuracy = store.dailyBackspaceRates().map(DailyAccuracyEntry.init)
         // Issue #102: IKI histogram
         ikiHistogram = store.ikiHistogramEntries()
+        // Issue #103: slowest bigrams by average IKI
+        slowBigrams = store.slowestBigrams(minCount: 5, limit: 20).map(SlowBigramEntry.init)
     }
 
     /// Lightweight refresh — reads only the live IKI ring buffer. Called by the 0.5s timer.

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -253,6 +253,44 @@ extension KeyCountStore {
         }
     }
 
+    /// Top N slowest bigrams by average IKI (Issue #103).
+    ///
+    /// - Parameters:
+    ///   - minCount: Minimum observation count; bigrams below this are excluded (default: 5).
+    ///   - limit:    Maximum number of results (default: 20).
+    /// - Returns: Array of `(bigram, avgIKI)` sorted descending by avg IKI (slowest first).
+    func slowestBigrams(minCount: Int = 5, limit: Int = 20) -> [(bigram: String, avgIKI: Double)] {
+        queue.sync {
+            var merged: [String: (sum: Double, count: Int)] = [:]
+
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
+               }) {
+                for row in rows {
+                    let key: String = row["bigram"]
+                    let sum: Double = row["iki_sum"]
+                    let cnt: Int    = row["iki_count"]
+                    merged[key] = (sum: sum, count: cnt)
+                }
+            }
+
+            for (bigram, p) in pending.bigramIKI {
+                let e = merged[bigram] ?? (sum: 0, count: 0)
+                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
+            }
+
+            return merged
+                .compactMap { bigram, data -> (bigram: String, avgIKI: Double)? in
+                    guard data.count >= minCount else { return nil }
+                    return (bigram: bigram, avgIKI: data.sum / Double(data.count))
+                }
+                .sorted { $0.avgIKI > $1.avgIKI }
+                .prefix(limit)
+                .map { $0 }
+        }
+    }
+
     /// All daily totals sorted ascending by date.
     func dailyTotals() -> [(date: String, total: Int)] {
         queue.sync {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -537,6 +537,22 @@ final class L10n {
         )
     }
 
+    var slowBigramsTitle: String {
+        ja("遅いキーペア (平均 IKI)", en: "Slow Bigrams (Avg IKI)")
+    }
+
+    var helpSlowBigrams: String {
+        ja(
+            "IKI (Inter-Key Interval) とは、2つのキーを連続して押したときの時間間隔 (ms) です。\n\nこのグラフは平均IKIが最も長いキーペア (ビグラム) を表示します。値が大きいほど打鍵が遅い組み合わせです。\n\nタイピング練習のターゲットとして活用できます。サンプル数が少ないビグラムは除外されています。",
+            en: "IKI (Inter-Key Interval) is the time in milliseconds between two consecutive keystrokes.\n\nThis chart shows the bigrams with the highest average IKI — the key pairs where your transitions are slowest.\n\nUse this to target slow combinations in typing practice. Bigrams with fewer than 5 samples are excluded."
+        )
+    }
+
+    var slowBigramsNoData: String {
+        ja("データなし — しばらく入力するとビグラムIKIデータが蓄積されます。",
+           en: "No data yet — type for a while to accumulate bigram IKI data.")
+    }
+
     func topAppTodayFormat(_ app: String, _ count: String) -> String {
         ja("🖥 \(app)  \(count)", en: "🖥 \(app)  \(count)")
     }


### PR DESCRIPTION
## Summary

- Adds `slowestBigrams(minCount:limit:)` to `KeyCountStore+Activity.swift` — reads `bigram_iki` table, returns top N bigrams sorted by avg IKI (slowest first)
- Adds `SlowBigramEntry` to `ChartsDataTypes.swift`
- Wires data into `ChartsWindowController` via `@Published var slowBigrams`
- Adds "Slow Bigrams (Avg IKI)" horizontal bar chart section to the Ergonomics tab, between "Top 20 Bigrams" and "Ergonomic Learning Curve"
- Adds bilingual L10n strings (title, help text, no-data message)

## Test plan

- [ ] Build passes (verified)
- [ ] Open Charts window → Ergonomics tab → "Slow Bigrams" section visible after a few keystrokes
- [ ] Empty state shows localised no-data message before data accumulates

Closes #103