### PR TITLE
feat: show avg IKI per finger in Ergonomics tab (#104)

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -8,11 +8,40 @@ extension ChartsView {
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
                 chartSection("Top 20 Bigrams", helpText: L10n.shared.helpBigrams, showSort: true) { bigramChart }
+                chartSection(L10n.shared.fingerIKITitle, helpText: L10n.shared.helpFingerIKI) { fingerIKIChart }
                 chartSection(L10n.shared.slowBigramsTitle, helpText: L10n.shared.helpSlowBigrams) { slowBigramChart }
                 chartSection("Ergonomic Learning Curve", helpText: L10n.shared.helpLearningCurve) { learningCurveChart }
                 chartSection("Layout Comparison", helpText: L10n.shared.helpLayoutComparison) { layoutComparisonSection }
             }
             .padding(24)
+        }
+    }
+
+    @ViewBuilder
+    var fingerIKIChart: some View {
+        if model.fingerIKI.isEmpty {
+            Text(L10n.shared.fingerIKINoData)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+        } else {
+            let fingerOrder = model.fingerIKI.map(\.finger)
+            Chart(model.fingerIKI) { item in
+                BarMark(
+                    x: .value("Avg IKI (ms)", item.avgIKI),
+                    y: .value("Finger", item.finger)
+                )
+                .foregroundStyle(Color.indigo.opacity(0.8))
+                .cornerRadius(3)
+                .annotation(position: .trailing) {
+                    Text(String(format: "%.0f ms", item.avgIKI))
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .chartYScale(domain: fingerOrder)
+            .chartXAxisLabel("ms", alignment: .trailing)
+            .chartLegend(.hidden)
+            .frame(height: CGFloat(model.fingerIKI.count * 36 + 24))
         }
     }
 

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -164,6 +164,17 @@ struct IKIHistogramEntry: Identifiable {
     let percentage: Double  // count / total * 100
 }
 
+struct FingerIKIEntry: Identifiable {
+    let id: String          // finger raw value e.g. "index"
+    let finger: String      // display label e.g. "Index"
+    let avgIKI: Double      // average inter-key interval in ms
+    init(_ t: (finger: String, avgIKI: Double)) {
+        id     = t.finger
+        finger = t.finger.prefix(1).uppercased() + t.finger.dropFirst()
+        avgIKI = t.avgIKI
+    }
+}
+
 struct SlowBigramEntry: Identifiable {
     let id: String          // bigram key e.g. "t→h"
     let bigram: String

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -51,6 +51,8 @@ final class ChartDataModel: ObservableObject {
     @Published var ikiHistogram:         [IKIHistogramEntry]    = []
     // Issue #103: slowest bigrams by average IKI
     @Published var slowBigrams:          [SlowBigramEntry]      = []
+    // Issue #104: average IKI broken down by finger
+    @Published var fingerIKI:            [FingerIKIEntry]       = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -115,6 +117,8 @@ final class ChartDataModel: ObservableObject {
         ikiHistogram = store.ikiHistogramEntries()
         // Issue #103: slowest bigrams by average IKI
         slowBigrams = store.slowestBigrams(minCount: 5, limit: 20).map(SlowBigramEntry.init)
+        // Issue #104: IKI per finger
+        fingerIKI = store.ikiPerFinger().map(FingerIKIEntry.init)
     }
 
     /// Lightweight refresh — reads only the live IKI ring buffer. Called by the 0.5s timer.

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -253,6 +253,52 @@ extension KeyCountStore {
         }
     }
 
+    /// Average IKI broken down by finger (Issue #104).
+    ///
+    /// Aggregates `bigram_iki` data by mapping the destination key of each bigram
+    /// to its finger via `ANSILayout`. IKI is attributed to the receiving finger —
+    /// how fast each finger responds when it is the next key to press.
+    ///
+    /// - Returns: Array of `(finger, avgIKI)` for fingers with data, sorted slowest-first.
+    func ikiPerFinger() -> [(finger: String, avgIKI: Double)] {
+        let layout = ANSILayout()
+        var perFinger: [String: (sum: Double, count: Int)] = [:]
+
+        queue.sync {
+            var merged: [String: (sum: Double, count: Int)] = [:]
+
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
+               }) {
+                for row in rows {
+                    let key: String = row["bigram"]
+                    let sum: Double = row["iki_sum"]
+                    let cnt: Int    = row["iki_count"]
+                    merged[key] = (sum: sum, count: cnt)
+                }
+            }
+            for (bigram, p) in pending.bigramIKI {
+                let e = merged[bigram] ?? (sum: 0, count: 0)
+                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
+            }
+
+            for (bigramKey, data) in merged where data.count > 0 {
+                guard let bigram = Bigram.parse(bigramKey),
+                      let finger = layout.finger(for: bigram.to) else { continue }
+                let e = perFinger[finger.rawValue] ?? (sum: 0, count: 0)
+                perFinger[finger.rawValue] = (sum: e.sum + data.sum, count: e.count + data.count)
+            }
+        }
+
+        return perFinger
+            .compactMap { finger, data -> (finger: String, avgIKI: Double)? in
+                guard data.count > 0 else { return nil }
+                return (finger: finger, avgIKI: data.sum / Double(data.count))
+            }
+            .sorted { $0.avgIKI > $1.avgIKI }
+    }
+
     /// Top N slowest bigrams by average IKI (Issue #103).
     ///
     /// - Parameters:

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -548,6 +548,22 @@ final class L10n {
         )
     }
 
+    var fingerIKITitle: String {
+        ja("指ごとの平均 IKI", en: "Avg IKI per Finger")
+    }
+
+    var helpFingerIKI: String {
+        ja(
+            "各指の平均 IKI (Inter-Key Interval) を示します。値が大きいほど、その指が次のキーを押すまでに時間がかかっています。\n\n集計方法: ビグラムの「受け取り側」の指に IKI を帰属させています。例えば「a→s」の IKI は中指 (s) に計上されます。\n\n練習のターゲットとして活用できます。",
+            en: "Shows the average IKI (Inter-Key Interval) for each finger. A higher value means that finger takes longer to engage as the receiving key in a transition.\n\nAggregation: IKI is attributed to the finger of the destination key in each bigram (e.g. the IKI of \"a→s\" is counted for the finger that presses \"s\").\n\nUse this to identify which fingers are slowest to respond."
+        )
+    }
+
+    var fingerIKINoData: String {
+        ja("データなし — しばらく入力すると指ごとの IKI データが蓄積されます。",
+           en: "No data yet — type for a while to accumulate per-finger IKI data.")
+    }
+
     var slowBigramsNoData: String {
         ja("データなし — しばらく入力するとビグラムIKIデータが蓄積されます。",
            en: "No data yet — type for a while to accumulate bigram IKI data.")


### PR DESCRIPTION
## Summary

- Adds `ikiPerFinger()` to `KeyCountStore+Activity.swift` — aggregates `bigram_iki` data by mapping each bigram's destination key to its finger via `ANSILayout`; IKI is attributed to the receiving finger
- Adds `FingerIKIEntry` to `ChartsDataTypes.swift`
- Wires `@Published var fingerIKI` in `ChartsWindowController`
- Adds "Avg IKI per Finger" bar chart (indigo, with ms value annotations) in Ergonomics tab above "Slow Bigrams"
- Adds bilingual L10n strings (title, help text, no-data message)

## Test plan

- [ ] Build passes (verified)
- [ ] Ergonomics tab shows "Avg IKI per Finger" with up to 5 bars (pinky/ring/middle/index/thumb)
- [ ] Empty state shows localised no-data message before data accumulates

Closes #104