### PR TITLE
feat: add manual WPM measurement to Live tab (#150)

### DIFF
--- a/Sources/KeyLens/Charts+LiveTab.swift
+++ b/Sources/KeyLens/Charts+LiveTab.swift
@@ -11,6 +11,12 @@ extension ChartsView {
                 .padding(.leading, 24)
                 .padding(.bottom, 24)
                 .padding(.trailing, 12)
+
+            Divider().padding(.horizontal, 24)
+
+            wpmMeasurementSection
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .onAppear {
@@ -91,5 +97,55 @@ extension ChartsView {
             .frame(width: recentIKIChartWidth, alignment: .leading)
             .fixedSize(horizontal: false, vertical: true)
         }
+    }
+
+    // MARK: - Manual WPM Measurement (Issue #150)
+
+    @ViewBuilder
+    var wpmMeasurementSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(L10n.shared.wpmMeasureTitle)
+                .font(.headline)
+
+            Text(L10n.shared.wpmMeasureHint)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 12) {
+                Button {
+                    if isMeasuringWPM {
+                        wpmResult = KeyCountStore.shared.stopWPMMeasurement()
+                        isMeasuringWPM = false
+                    } else {
+                        KeyCountStore.shared.startWPMMeasurement()
+                        wpmResult = nil
+                        isMeasuringWPM = true
+                    }
+                } label: {
+                    Label(
+                        isMeasuringWPM ? L10n.shared.wpmMeasureStop : L10n.shared.wpmMeasureStart,
+                        systemImage: isMeasuringWPM ? "stop.circle.fill" : "play.circle.fill"
+                    )
+                    .font(.body.bold())
+                    .foregroundStyle(isMeasuringWPM ? .red : .green)
+                }
+                .buttonStyle(.plain)
+
+                if isMeasuringWPM {
+                    Label("Recording…", systemImage: "record.circle")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            if let r = wpmResult {
+                Text(L10n.shared.wpmMeasureResult(wpm: r.wpm, duration: r.duration, keystrokes: r.keystrokes))
+                    .font(.title2.monospacedDigit().bold())
+                    .foregroundStyle(.orange)
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: isMeasuringWPM)
+        .animation(.easeInOut(duration: 0.2), value: wpmResult != nil)
     }
 }

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -19,6 +19,10 @@ struct ChartsView: View {
     @State var liveTimer: Timer? = nil
     /// Selected finger filter for the Slow Bigrams chart. nil = All (Issue #153).
     @State var slowBigramFingerFilter: String? = nil
+    /// Whether a manual WPM session is active (Issue #150).
+    @State var isMeasuringWPM: Bool = false
+    /// Result of the last completed WPM session.
+    @State var wpmResult: (wpm: Double, duration: TimeInterval, keystrokes: Int)? = nil
 
     /// Fixed width keeps the live IKI snapshot compact when copying to the clipboard.
     /// 最新20打鍵グラフのコピーサイズを安定させるための固定幅。

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -475,6 +475,36 @@ extension KeyCountStore {
         queue.sync { recentIKIs }
     }
 
+    // MARK: - Manual WPM measurement (Issue #150)
+
+    /// Starts a new WPM measurement session. Resets any previous session.
+    func startWPMMeasurement() {
+        queue.sync {
+            wpmSessionStart = Date()
+            wpmSessionKeystrokes = 0
+        }
+    }
+
+    /// Stops the active session and returns the result.
+    /// Returns nil if no session was running.
+    func stopWPMMeasurement() -> (wpm: Double, duration: TimeInterval, keystrokes: Int)? {
+        queue.sync {
+            guard let start = wpmSessionStart else { return nil }
+            let duration = Date().timeIntervalSince(start)
+            let keystrokes = wpmSessionKeystrokes
+            wpmSessionStart = nil
+            wpmSessionKeystrokes = 0
+            guard duration > 0, keystrokes > 0 else { return nil }
+            let wpm = (Double(keystrokes) / 5.0) / (duration / 60.0)
+            return (wpm: wpm, duration: duration, keystrokes: keystrokes)
+        }
+    }
+
+    /// Whether a WPM measurement session is currently active.
+    var isWPMMeasuring: Bool {
+        queue.sync { wpmSessionStart != nil }
+    }
+
     /// All keys sorted by cumulative count descending, including today's count.
     func allEntries() -> [(key: String, total: Int, today: Int)] {
         queue.sync {

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -182,6 +182,10 @@ final class KeyCountStore {
     private(set) var recentIKIs: [(key: String, iki: Double)] = []
     private let recentIKICapacity = 20
 
+    // Manual WPM measurement session (Issue #150). All access on `queue`.
+    var wpmSessionStart: Date? = nil
+    var wpmSessionKeystrokes: Int = 0
+
     private init() {
         let dir = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -245,6 +249,9 @@ final class KeyCountStore {
             // Per-device → SQLite pending
             store.deviceCounts[deviceName, default: 0] += 1
             pending.dailyDevices[today, default: [:]][deviceName, default: 0] += 1
+
+            // Manual WPM session keystroke counter
+            if wpmSessionStart != nil { wpmSessionKeystrokes += 1 }
 
             // Update today count cache
             if _todayCacheDate != today {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -505,6 +505,35 @@ final class L10n {
         )
     }
 
+    // MARK: - Manual WPM Measurement (Issue #150)
+
+    var wpmMeasureTitle: String {
+        ja("WPM 計測", en: "WPM Measurement")
+    }
+
+    var wpmMeasureStart: String {
+        ja("計測開始", en: "Start")
+    }
+
+    var wpmMeasureStop: String {
+        ja("計測停止", en: "Stop")
+    }
+
+    var wpmMeasureHint: String {
+        ja("「計測開始」を押してからタイピングし、「計測停止」を押すとWPMが表示されます。",
+           en: "Press Start, type freely, then press Stop to see your WPM.")
+    }
+
+    func wpmMeasureResult(wpm: Double, duration: TimeInterval, keystrokes: Int) -> String {
+        let mins = Int(duration) / 60
+        let secs = Int(duration) % 60
+        let timeStr = mins > 0 ? "\(mins)m \(secs)s" : "\(secs)s"
+        return ja(
+            String(format: "%.0f WPM  (%d打鍵 / %@)", wpm, keystrokes, timeStr),
+            en: String(format: "%.0f WPM  (%d keystrokes / %@)", wpm, keystrokes, timeStr)
+        )
+    }
+
     var chartTitleIKIHistogram: String {
         ja("IKI分布ヒストグラム", en: "IKI Distribution Histogram")
     }


### PR DESCRIPTION
## Summary

- Adds `startWPMMeasurement()` / `stopWPMMeasurement()` to `KeyCountStore`
- Active session keystroke count incremented in `increment()` on the serial queue
- Start/Stop button added to the Live tab below the IKI chart
- Result displays: `72 WPM (320 keystrokes / 45s)` in orange after stopping
- Bilingual L10n strings (EN + JA)

## How it works

1. Press **Start** → session begins, keystroke counter resets
2. Type freely
3. Press **Stop** → `wpm = (keystrokes / 5) / (duration / 60)` displayed immediately
4. Does not affect daily WPM tracking

## Test plan

- [ ] Build passes (verified)
- [ ] Start → type → Stop shows WPM result
- [ ] Starting again resets previous result
- [ ] Daily WPM chart unaffected

Closes #150