### PR TITLE
feat: add configurable hotkey to start/stop WPM measurement (#151)

### DIFF
--- a/Sources/KeyLens/Charts+LiveTab.swift
+++ b/Sources/KeyLens/Charts+LiveTab.swift
@@ -111,6 +111,7 @@ extension ChartsView {
                 .font(.caption)
                 .foregroundStyle(.secondary)
 
+            // Start / Stop button
             HStack(spacing: 12) {
                 Button {
                     if isMeasuringWPM {
@@ -138,14 +139,49 @@ extension ChartsView {
                 }
             }
 
+            // Result
             if let r = wpmResult {
                 Text(L10n.shared.wpmMeasureResult(wpm: r.wpm, duration: r.duration, keystrokes: r.keystrokes))
                     .font(.title2.monospacedDigit().bold())
                     .foregroundStyle(.orange)
                     .transition(.opacity)
             }
+
+            // Hotkey display and recorder
+            HStack(spacing: 6) {
+                Text(L10n.shared.wpmHotkeyLabel)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Text(wpmHotkeyDisplay)
+                    .font(.caption.monospaced())
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Color.secondary.opacity(0.15))
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+
+                Button(isRecordingHotkey ? L10n.shared.wpmHotkeyRecording : L10n.shared.wpmHotkeyRecord) {
+                    isRecordingHotkey = true
+                    WPMHotkeyManager.shared.recordNextHotkey { newDisplay in
+                        wpmHotkeyDisplay = newDisplay
+                        isRecordingHotkey = false
+                    }
+                }
+                .buttonStyle(.plain)
+                .font(.caption)
+                .foregroundStyle(isRecordingHotkey ? .orange : .accentColor)
+                .disabled(isRecordingHotkey)
+            }
         }
         .animation(.easeInOut(duration: 0.2), value: isMeasuringWPM)
         .animation(.easeInOut(duration: 0.2), value: wpmResult != nil)
+        // Sync UI when hotkey toggles measurement from outside the window
+        .onReceive(NotificationCenter.default.publisher(for: .wpmMeasurementStarted)) { _ in
+            wpmResult = nil
+            isMeasuringWPM = true
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .wpmMeasurementStopped)) { note in
+            isMeasuringWPM = false
+            wpmResult = note.object as? (wpm: Double, duration: TimeInterval, keystrokes: Int)
+        }
     }
 }

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -23,6 +23,10 @@ struct ChartsView: View {
     @State var isMeasuringWPM: Bool = false
     /// Result of the last completed WPM session.
     @State var wpmResult: (wpm: Double, duration: TimeInterval, keystrokes: Int)? = nil
+    /// Current hotkey display string (Issue #151).
+    @State var wpmHotkeyDisplay: String = WPMHotkeyManager.shared.displayString
+    /// Whether the app is waiting for the user to press a new hotkey.
+    @State var isRecordingHotkey: Bool = false
 
     /// Fixed width keeps the live IKI snapshot compact when copying to the clipboard.
     /// 最新20打鍵グラフのコピーサイズを安定させるための固定幅。

--- a/Sources/KeyLens/KeyboardMonitor.swift
+++ b/Sources/KeyLens/KeyboardMonitor.swift
@@ -210,6 +210,11 @@ extension KeyboardMonitor {
             return Unmanaged.passRetained(event)
         }
 
+        // Check WPM hotkey before recording the keystroke (Issue #151)
+        if type == .keyDown, WPMHotkeyManager.shared.matches(event: event) {
+            DispatchQueue.main.async { WPMHotkeyManager.shared.toggle() }
+        }
+
         let now = Date()
         let appName = NSWorkspace.shared.frontmostApplication?.localizedName
         let result = KeyCountStore.shared.increment(key: name, at: now, appName: appName)

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -534,6 +534,18 @@ final class L10n {
         )
     }
 
+    var wpmHotkeyLabel: String {
+        ja("ショートカット:", en: "Hotkey:")
+    }
+
+    var wpmHotkeyRecord: String {
+        ja("変更…", en: "Change…")
+    }
+
+    var wpmHotkeyRecording: String {
+        ja("キーを押してください…", en: "Press a key combo…")
+    }
+
     var chartTitleIKIHistogram: String {
         ja("IKI分布ヒストグラム", en: "IKI Distribution Histogram")
     }

--- a/Sources/KeyLens/WPMHotkeyManager.swift
+++ b/Sources/KeyLens/WPMHotkeyManager.swift
@@ -1,0 +1,107 @@
+import AppKit
+import KeyLensCore
+
+/// Manages the global hotkey for toggling manual WPM measurement (Issue #151).
+///
+/// The hotkey is checked inside the existing CGEventTap (KeyboardMonitor)
+/// to avoid requiring an additional global event monitor.
+/// Default hotkey: ⌃⌥M (Control+Option+M).
+final class WPMHotkeyManager {
+    static let shared = WPMHotkeyManager()
+
+    private static let keyCodeKey   = "wpmHotkeyKeyCode"
+    private static let modifiersKey = "wpmHotkeyModifiers"
+
+    // Default: ⌃⌥M
+    private static let defaultKeyCode: UInt16 = 46  // 'm'
+    private static let defaultModifiers: CGEventFlags = [.maskControl, .maskAlternate]
+
+    var keyCode: UInt16 {
+        get {
+            let v = UserDefaults.standard.integer(forKey: Self.keyCodeKey)
+            return v > 0 ? UInt16(v) : Self.defaultKeyCode
+        }
+        set { UserDefaults.standard.set(Int(newValue), forKey: Self.keyCodeKey) }
+    }
+
+    var modifierFlags: CGEventFlags {
+        get {
+            let v = UserDefaults.standard.integer(forKey: Self.modifiersKey)
+            return v != 0 ? CGEventFlags(rawValue: UInt64(v)) : Self.defaultModifiers
+        }
+        set { UserDefaults.standard.set(Int(newValue.rawValue), forKey: Self.modifiersKey) }
+    }
+
+    private init() {}
+
+    // MARK: - Hotkey matching
+
+    /// Returns true if the given CGEvent matches the configured hotkey.
+    func matches(event: CGEvent) -> Bool {
+        let code = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        guard code == keyCode else { return false }
+        let relevant: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+        return event.flags.intersection(relevant) == modifierFlags.intersection(relevant)
+    }
+
+    // MARK: - Toggle
+
+    /// Toggles WPM measurement and posts the appropriate notification.
+    func toggle() {
+        let store = KeyCountStore.shared
+        if store.isWPMMeasuring {
+            let result = store.stopWPMMeasurement()
+            NotificationCenter.default.post(name: .wpmMeasurementStopped, object: result)
+        } else {
+            store.startWPMMeasurement()
+            NotificationCenter.default.post(name: .wpmMeasurementStarted, object: nil)
+        }
+    }
+
+    // MARK: - Display
+
+    /// Human-readable hotkey string, e.g. "⌃⌥M".
+    var displayString: String {
+        var s = ""
+        let f = modifierFlags
+        if f.contains(.maskControl)   { s += "⌃" }
+        if f.contains(.maskAlternate) { s += "⌥" }
+        if f.contains(.maskShift)     { s += "⇧" }
+        if f.contains(.maskCommand)   { s += "⌘" }
+        s += KeyboardMonitor.keyName(for: keyCode).uppercased()
+        return s
+    }
+
+    // MARK: - Hotkey recording
+
+    /// Records the next key event from a local NSEvent monitor and saves it as the new hotkey.
+    /// Calls `completion` on the main thread when done.
+    func recordNextHotkey(completion: @escaping (String) -> Void) {
+        var monitor: Any?
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            let relevant = NSEvent.ModifierFlags([.control, .option, .shift, .command])
+            guard !event.modifierFlags.intersection(relevant).isEmpty else { return event }
+
+            self.keyCode = event.keyCode
+
+            var cgFlags = CGEventFlags()
+            if event.modifierFlags.contains(.control) { cgFlags.insert(.maskControl) }
+            if event.modifierFlags.contains(.option)  { cgFlags.insert(.maskAlternate) }
+            if event.modifierFlags.contains(.shift)   { cgFlags.insert(.maskShift) }
+            if event.modifierFlags.contains(.command) { cgFlags.insert(.maskCommand) }
+            self.modifierFlags = cgFlags
+
+            if let m = monitor { NSEvent.removeMonitor(m) }
+            DispatchQueue.main.async { completion(self.displayString) }
+            return nil  // consume the event
+        }
+    }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let wpmMeasurementStarted = Notification.Name("com.keylens.wpmMeasurementStarted")
+    static let wpmMeasurementStopped = Notification.Name("com.keylens.wpmMeasurementStopped")
+}


### PR DESCRIPTION
## Summary

- `WPMHotkeyManager.swift` — singleton storing keyCode + modifierFlags in `UserDefaults`, default `⌃⌥M`
- Hotkey is checked inside the existing `CGEventTap` (`KeyboardMonitor.handleEvent`) — no extra permissions or monitors needed
- Toggle fires `wpmMeasurementStarted` / `wpmMeasurementStopped` notifications so the Live tab UI stays in sync even when the hotkey is pressed without the window open
- Live tab shows current hotkey label + "Change…" button; pressing "Change…" captures the next key combo and saves it

## How it works

1. Press `⌃⌥M` anywhere → measurement starts (or stops)
2. In the Live tab → WPM Measurement section → press **Change…** → press desired combo → saved immediately
3. Hotkey persists across app restarts via `UserDefaults`

## Test plan

- [ ] Build passes (verified)
- [ ] `⌃⌥M` toggles start/stop without Charts window open
- [ ] Live tab UI reflects hotkey state correctly
- [ ] "Change…" records a new combo and updates the display
- [ ] New combo persists after app restart

Closes #151