### PR TITLE
feat: add key transition analysis to Ergonomics tab (Close #98)

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -10,6 +10,7 @@ extension ChartsView {
                 chartSection("Top 20 Bigrams", helpText: L10n.shared.helpBigrams, showSort: true) { bigramChart }
                 chartSection(L10n.shared.fingerIKITitle, helpText: L10n.shared.helpFingerIKI) { fingerIKIChart }
                 chartSection(L10n.shared.slowBigramsTitle, helpText: L10n.shared.helpSlowBigrams) { slowBigramChart }
+                chartSection(L10n.shared.keyTransitionTitle, helpText: L10n.shared.helpKeyTransition) { keyTransitionSection }
                 chartSection("Ergonomic Learning Curve", helpText: L10n.shared.helpLearningCurve) { learningCurveChart }
                 chartSection("Layout Comparison", helpText: L10n.shared.helpLayoutComparison) { layoutComparisonSection }
             }
@@ -90,6 +91,83 @@ extension ChartsView {
                 .chartLegend(.hidden)
                 .frame(height: CGFloat(filtered.count * 26 + 24))
             }
+        }
+    }
+
+    // MARK: - Issue #98: Key Transition Analysis
+
+    @ViewBuilder
+    var keyTransitionSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Key input field
+            HStack(spacing: 8) {
+                TextField(L10n.shared.keyTransitionPlaceholder, text: $keyTransitionTarget)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(width: 160)
+                    .onChange(of: keyTransitionTarget) { newValue in
+                        model.reloadKeyTransitions(for: newValue)
+                    }
+
+                if !keyTransitionTarget.isEmpty {
+                    Button {
+                        keyTransitionTarget = ""
+                        model.reloadKeyTransitions(for: "")
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            if keyTransitionTarget.isEmpty {
+                Text(L10n.shared.keyTransitionPlaceholder)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 40, alignment: .center)
+            } else {
+                // Incoming transitions
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(L10n.shared.keyTransitionIncomingTitle(keyTransitionTarget))
+                        .font(.caption).foregroundStyle(.secondary)
+                    keyTransitionChart(entries: model.keyTransitionIncoming, color: .teal)
+                }
+
+                // Outgoing transitions
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(L10n.shared.keyTransitionOutgoingTitle(keyTransitionTarget))
+                        .font(.caption).foregroundStyle(.secondary)
+                    keyTransitionChart(entries: model.keyTransitionOutgoing, color: .purple)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func keyTransitionChart(entries: [KeyTransitionEntry], color: Color) -> some View {
+        if entries.isEmpty {
+            Text(L10n.shared.keyTransitionNoData)
+                .foregroundStyle(.secondary)
+                .font(.caption)
+                .frame(maxWidth: .infinity, minHeight: 40, alignment: .center)
+        } else {
+            let order = entries.map(\.bigram)
+            Chart(entries) { item in
+                BarMark(
+                    x: .value("Avg IKI (ms)", item.avgIKI),
+                    y: .value("Bigram", item.bigram)
+                )
+                .foregroundStyle(color.opacity(0.8))
+                .cornerRadius(3)
+                .annotation(position: .trailing) {
+                    Text("n=\(item.count)")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .chartYScale(domain: order)
+            .chartXAxisLabel("ms", alignment: .trailing)
+            .chartLegend(.hidden)
+            .frame(height: CGFloat(entries.count * 28 + 24))
         }
     }
 

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -181,3 +181,15 @@ struct SlowBigramEntry: Identifiable {
     let avgIKI: Double      // average inter-key interval in ms
     init(_ t: (bigram: String, avgIKI: Double)) { id = t.bigram; bigram = t.bigram; avgIKI = t.avgIKI }
 }
+
+/// One row in the Key Transition analysis chart (Issue #98).
+/// キー遷移分析チャートの1行。
+struct KeyTransitionEntry: Identifiable {
+    let id: String          // bigram key e.g. "d→f"
+    let bigram: String      // display label
+    let avgIKI: Double      // average inter-key interval in ms
+    let count: Int          // number of samples
+    init(_ t: (bigram: String, avgIKI: Double, count: Int)) {
+        id = t.bigram; bigram = t.bigram; avgIKI = t.avgIKI; count = t.count
+    }
+}

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -27,6 +27,8 @@ struct ChartsView: View {
     @State var wpmHotkeyDisplay: String = WPMHotkeyManager.shared.displayString
     /// Whether the app is waiting for the user to press a new hotkey.
     @State var isRecordingHotkey: Bool = false
+    /// Target key for the Key Transition analysis section (Issue #98).
+    @State var keyTransitionTarget: String = ""
 
     /// Fixed width keeps the live IKI snapshot compact when copying to the clipboard.
     /// 最新20打鍵グラフのコピーサイズを安定させるための固定幅。

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -53,6 +53,9 @@ final class ChartDataModel: ObservableObject {
     @Published var slowBigrams:          [SlowBigramEntry]      = []
     // Issue #104: average IKI broken down by finger
     @Published var fingerIKI:            [FingerIKIEntry]       = []
+    // Issue #98: key transition analysis — incoming and outgoing transitions for the selected key
+    @Published var keyTransitionIncoming: [KeyTransitionEntry]  = []
+    @Published var keyTransitionOutgoing: [KeyTransitionEntry]  = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -119,6 +122,18 @@ final class ChartDataModel: ObservableObject {
         slowBigrams = store.slowestBigrams(minCount: 5, limit: 20).map(SlowBigramEntry.init)
         // Issue #104: IKI per finger
         fingerIKI = store.ikiPerFinger().map(FingerIKIEntry.init)
+    }
+
+    /// Reloads key transition data for the given target key (Issue #98).
+    func reloadKeyTransitions(for key: String) {
+        guard !key.isEmpty else {
+            keyTransitionIncoming = []
+            keyTransitionOutgoing = []
+            return
+        }
+        let result = KeyCountStore.shared.keyTransitions(for: key)
+        keyTransitionIncoming = result.incoming.map(KeyTransitionEntry.init)
+        keyTransitionOutgoing = result.outgoing.map(KeyTransitionEntry.init)
     }
 
     /// Lightweight refresh — reads only the live IKI ring buffer. Called by the 0.5s timer.

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -337,6 +337,63 @@ extension KeyCountStore {
         }
     }
 
+    /// Incoming and outgoing transitions for a specific key, ranked by avg IKI (Issue #98).
+    ///
+    /// - Parameters:
+    ///   - key:      The target key to inspect (case-sensitive, matches on-disk format).
+    ///   - minCount: Minimum sample count; transitions below this threshold are excluded (default: 3).
+    ///   - limit:    Maximum results per direction (default: 15).
+    /// - Returns: Tuple of incoming (`*→key`) and outgoing (`key→*`) arrays, each sorted slowest-first.
+    func keyTransitions(
+        for key: String,
+        minCount: Int = 3,
+        limit: Int = 15
+    ) -> (incoming: [(bigram: String, avgIKI: Double, count: Int)],
+          outgoing: [(bigram: String, avgIKI: Double, count: Int)]) {
+        queue.sync {
+            var merged: [String: (sum: Double, count: Int)] = [:]
+
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
+               }) {
+                for row in rows {
+                    let k: String = row["bigram"]
+                    let sum: Double = row["iki_sum"]
+                    let cnt: Int    = row["iki_count"]
+                    merged[k] = (sum: sum, count: cnt)
+                }
+            }
+            for (bigram, p) in pending.bigramIKI {
+                let e = merged[bigram] ?? (sum: 0, count: 0)
+                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
+            }
+
+            func toEntry(_ kv: (key: String, value: (sum: Double, count: Int)))
+                -> (bigram: String, avgIKI: Double, count: Int)? {
+                guard kv.value.count >= minCount else { return nil }
+                return (bigram: kv.key, avgIKI: kv.value.sum / Double(kv.value.count), count: kv.value.count)
+            }
+
+            let incomingSuffix = "→\(key)"
+            let outgoingPrefix = "\(key)→"
+
+            let incoming = merged
+                .filter { $0.key.hasSuffix(incomingSuffix) }
+                .compactMap { toEntry($0) }
+                .sorted { $0.avgIKI > $1.avgIKI }
+                .prefix(limit).map { $0 }
+
+            let outgoing = merged
+                .filter { $0.key.hasPrefix(outgoingPrefix) }
+                .compactMap { toEntry($0) }
+                .sorted { $0.avgIKI > $1.avgIKI }
+                .prefix(limit).map { $0 }
+
+            return (incoming: incoming, outgoing: outgoing)
+        }
+    }
+
     /// All daily totals sorted ascending by date.
     func dailyTotals() -> [(date: String, total: Int)] {
         queue.sync {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -610,6 +610,36 @@ final class L10n {
            en: "No data yet — type for a while to accumulate bigram IKI data.")
     }
 
+    // MARK: - Issue #98: Key Transition Analysis
+
+    var keyTransitionTitle: String {
+        ja("キー遷移分析", en: "Key Transition Analysis")
+    }
+
+    var helpKeyTransition: String {
+        ja(
+            "調べたいキーを入力すると、そのキーへの遷移 (*→K) とそのキーからの遷移 (K→*) を平均IKI順で表示します。\n\n値が大きいほど遅い組み合わせです。タイピング練習のターゲット発見に活用できます。サンプル数が少ない遷移は除外されます。",
+            en: "Enter a key to inspect its incoming (*→K) and outgoing (K→*) transitions, ranked by average IKI.\n\nHigher values mean slower transitions. Use this to find specific key pairs to target in practice. Transitions with fewer than 3 samples are excluded."
+        )
+    }
+
+    var keyTransitionPlaceholder: String {
+        ja("キーを入力 (例: f)", en: "Type a key (e.g. f)")
+    }
+
+    func keyTransitionIncomingTitle(_ key: String) -> String {
+        ja("→ \(key) への遷移 (遅い順)", en: "Incoming → \(key) (slowest first)")
+    }
+
+    func keyTransitionOutgoingTitle(_ key: String) -> String {
+        ja("\(key) → からの遷移 (遅い順)", en: "Outgoing \(key) → (slowest first)")
+    }
+
+    var keyTransitionNoData: String {
+        ja("該当する遷移データがありません。サンプル数が少ない場合は除外されます。",
+           en: "No transition data found. Transitions with fewer than 3 samples are excluded.")
+    }
+
     func topAppTodayFormat(_ app: String, _ count: String) -> String {
         ja("🖥 \(app)  \(count)", en: "🖥 \(app)  \(count)")
     }


### PR DESCRIPTION
## Summary

- Adds a **Key Transition Analysis** section to the Ergonomics tab
- User types a key (e.g. `f`), and sees two ranked bar charts:
  - **Incoming** (`*→f`): which keys before `f` are slowest
  - **Outgoing** (`f→*`): which keys after `f` are slowest
- Data sourced from existing `bigram_iki` table; transitions with fewer than 3 samples are excluded
- Bilingual labels via L10n (EN/JA)

## Files Changed

| File | Change |
|------|--------|
| `ChartsDataTypes.swift` | Add `KeyTransitionEntry` struct |
| `KeyCountStore+Activity.swift` | Add `keyTransitions(for:minCount:limit:)` |
| `ChartsWindowController.swift` | Add published arrays + `reloadKeyTransitions(for:)` |
| `ChartsView.swift` | Add `@State var keyTransitionTarget` |
| `Charts+ErgonomicsTab.swift` | Add `keyTransitionSection` + `keyTransitionChart` |
| `L10n.swift` | Add 6 new bilingual strings |

## Test plan

- [ ] Open Ergonomics tab → "Key Transition Analysis" section appears
- [ ] Type `f` → incoming (teal) and outgoing (purple) charts render
- [ ] Type `Space` → shows Space-related transitions
- [ ] Clear with ✕ button → charts hide
- [ ] Type a key with no data → "No transition data found" message shown