### PR TITLE
feat: add layout efficiency comparison (QWERTY/Colemak/Dvorak) (Close #61)

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -10,6 +10,7 @@ extension ChartsView {
                 chartSection("Top 20 Bigrams", helpText: L10n.shared.helpBigrams, showSort: true) { bigramChart }
                 chartSection(L10n.shared.fingerIKITitle, helpText: L10n.shared.helpFingerIKI) { fingerIKIChart }
                 chartSection(L10n.shared.slowBigramsTitle, helpText: L10n.shared.helpSlowBigrams) { slowBigramChart }
+                chartSection(L10n.shared.layoutEfficiencyTitle, helpText: L10n.shared.helpLayoutEfficiency) { layoutEfficiencySection }
                 chartSection(L10n.shared.keyTransitionTitle, helpText: L10n.shared.helpKeyTransition) { keyTransitionSection }
                 chartSection("Ergonomic Learning Curve", helpText: L10n.shared.helpLearningCurve) { learningCurveChart }
                 chartSection("Layout Comparison", helpText: L10n.shared.helpLayoutComparison) { layoutComparisonSection }
@@ -91,6 +92,65 @@ extension ChartsView {
                 .chartLegend(.hidden)
                 .frame(height: CGFloat(filtered.count * 26 + 24))
             }
+        }
+    }
+
+    // MARK: - Issue #61: Layout Efficiency Comparison
+
+    @ViewBuilder
+    var layoutEfficiencySection: some View {
+        if model.layoutEfficiency.isEmpty {
+            Text(L10n.shared.layoutEfficiencyNoData)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 40, alignment: .center)
+        } else {
+            let best = model.layoutEfficiency.first
+            Grid(alignment: .trailing, horizontalSpacing: 24, verticalSpacing: 0) {
+                // Header
+                GridRow {
+                    Text("Layout")
+                        .font(.caption).bold().foregroundStyle(.secondary)
+                        .gridColumnAlignment(.leading)
+                    Text(L10n.shared.layoutEfficiencySFBHeader)
+                        .font(.caption).bold().foregroundStyle(.secondary)
+                    Text(L10n.shared.layoutEfficiencyAltHeader)
+                        .font(.caption).bold().foregroundStyle(.secondary)
+                }
+                .padding(.bottom, 6)
+
+                Divider().gridCellUnsizedAxes(.horizontal)
+
+                ForEach(model.layoutEfficiency) { entry in
+                    let isBest = entry.id == best?.id
+                    GridRow {
+                        HStack(spacing: 4) {
+                            Text(entry.name)
+                                .font(.callout)
+                                .fontWeight(isBest ? .semibold : .regular)
+                            if isBest {
+                                Image(systemName: "crown.fill")
+                                    .font(.caption2)
+                                    .foregroundStyle(.yellow)
+                            }
+                        }
+                        .gridColumnAlignment(.leading)
+
+                        Text(String(format: "%.1f%%", entry.sameFingerRate * 100))
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(isBest ? Color.green : .primary)
+
+                        Text(String(format: "%.1f%%", entry.handAlternationRate * 100))
+                            .font(.callout.monospacedDigit())
+                            .foregroundStyle(isBest ? Color.green : .primary)
+                    }
+                    .padding(.vertical, 5)
+                }
+            }
+            .padding(.vertical, 4)
+
+            Text("Based on \(model.layoutEfficiency.first?.totalBigrams.formatted() ?? "0") bigrams")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
     }
 

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -182,6 +182,25 @@ struct SlowBigramEntry: Identifiable {
     init(_ t: (bigram: String, avgIKI: Double)) { id = t.bigram; bigram = t.bigram; avgIKI = t.avgIKI }
 }
 
+/// Layout efficiency comparison entry (Issue #61).
+/// One row per keyboard layout: shows same-finger bigram rate and hand-alternation rate
+/// computed from the user's actual bigram frequency distribution.
+/// レイアウト効率比較の1行：ユーザーの実打鍵ビグラムに基づく同指率・交互打鍵率。
+struct LayoutEfficiencyEntry: Identifiable {
+    let id: String          // layout name e.g. "QWERTY"
+    let name: String
+    let sameFingerRate: Double      // lower is better
+    let handAlternationRate: Double // higher is better
+    let totalBigrams: Int
+    init(name: String, sameFingerRate: Double, handAlternationRate: Double, totalBigrams: Int) {
+        id = name
+        self.name = name
+        self.sameFingerRate = sameFingerRate
+        self.handAlternationRate = handAlternationRate
+        self.totalBigrams = totalBigrams
+    }
+}
+
 /// One row in the Key Transition analysis chart (Issue #98).
 /// キー遷移分析チャートの1行。
 struct KeyTransitionEntry: Identifiable {

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -56,6 +56,8 @@ final class ChartDataModel: ObservableObject {
     // Issue #98: key transition analysis — incoming and outgoing transitions for the selected key
     @Published var keyTransitionIncoming: [KeyTransitionEntry]  = []
     @Published var keyTransitionOutgoing: [KeyTransitionEntry]  = []
+    // Issue #61: layout efficiency comparison — QWERTY vs Colemak vs Dvorak
+    @Published var layoutEfficiency:      [LayoutEfficiencyEntry] = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -122,6 +124,8 @@ final class ChartDataModel: ObservableObject {
         slowBigrams = store.slowestBigrams(minCount: 5, limit: 20).map(SlowBigramEntry.init)
         // Issue #104: IKI per finger
         fingerIKI = store.ikiPerFinger().map(FingerIKIEntry.init)
+        // Issue #61: layout efficiency comparison
+        layoutEfficiency = store.layoutEfficiencyScores()
     }
 
     /// Reloads key transition data for the given target key (Issue #98).

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -254,6 +254,59 @@ extension KeyCountStore {
     }
 }
 
+// MARK: - Issue #61: Layout Efficiency Scores
+
+extension KeyCountStore {
+
+    /// Computes same-finger bigram rate and hand-alternation rate for QWERTY, Colemak, and Dvorak,
+    /// applied to the user's actual all-time bigram frequency distribution.
+    ///
+    /// Allows the user to see how their real typing patterns would perform across layouts without
+    /// needing to type on each layout or export data to an external tool.
+    ///
+    /// - Returns: One entry per layout, sorted by hand-alternation rate descending (best first).
+    func layoutEfficiencyScores() -> [LayoutEfficiencyEntry] {
+        let bigrams = queue.sync { store.bigramCounts }
+        guard !bigrams.isEmpty else { return [] }
+
+        let layouts: [(name: String, layout: any KeyboardLayout)] = [
+            ("QWERTY",  ANSILayout()),
+            ("Colemak", ColemakLayout()),
+            ("Dvorak",  DvorakLayout()),
+        ]
+
+        return layouts.map { layoutName, layout in
+            var sfbCount = 0
+            var altCount = 0
+            var total    = 0
+
+            for (bigramKey, count) in bigrams {
+                guard let b     = Bigram.parse(bigramKey),
+                      let handA = layout.hand(for: b.from),
+                      let handB = layout.hand(for: b.to) else { continue }
+                total += count
+                if handA != handB {
+                    altCount += count
+                } else if let fingerA = layout.finger(for: b.from),
+                          let fingerB = layout.finger(for: b.to),
+                          fingerA == fingerB {
+                    sfbCount += count
+                }
+            }
+
+            let sfbRate = total > 0 ? Double(sfbCount) / Double(total) : 0
+            let altRate = total > 0 ? Double(altCount) / Double(total) : 0
+            return LayoutEfficiencyEntry(
+                name: layoutName,
+                sameFingerRate: sfbRate,
+                handAlternationRate: altRate,
+                totalBigrams: total
+            )
+        }
+        .sorted { $0.handAlternationRate > $1.handAlternationRate }
+    }
+}
+
 // MARK: - Private helpers
 
 extension KeyCountStore {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -612,6 +612,34 @@ final class L10n {
 
     // MARK: - Issue #98: Key Transition Analysis
 
+    // MARK: - Issue #61: Layout Efficiency Score
+
+    var layoutEfficiencyTitle: String {
+        ja("レイアウト効率比較", en: "Layout Efficiency Comparison")
+    }
+
+    var helpLayoutEfficiency: String {
+        ja(
+            "あなたの実際の打鍵ビグラムデータを使い、QWERTY / Colemak / Dvorak それぞれで「同指率」と「交互打鍵率」を計算します。\n\n同指率が低いほど、交互打鍵率が高いほど効率的なレイアウトです。\n\n※ あなたが実際に使っているレイアウトで記録されたビグラムを各レイアウトの指割り当てに当てはめた推定値です。",
+            en: "Applies your actual bigram frequencies to the finger assignments of QWERTY, Colemak, and Dvorak to estimate same-finger bigram rate (SFB) and hand-alternation rate for each layout.\n\nLower SFB and higher alternation = more efficient layout for your typing patterns.\n\nNote: these are estimates based on remapping your recorded bigrams to each layout's finger assignments."
+        )
+    }
+
+    var layoutEfficiencyNoData: String {
+        ja("データなし — しばらく入力するとビグラムデータが蓄積されます。",
+           en: "No data yet — type for a while to accumulate bigram data.")
+    }
+
+    var layoutEfficiencySFBHeader: String {
+        ja("同指率 (低いほど良い)", en: "Same-Finger Rate (lower = better)")
+    }
+
+    var layoutEfficiencyAltHeader: String {
+        ja("交互打鍵率 (高いほど良い)", en: "Hand Alternation (higher = better)")
+    }
+
+    // MARK: - Issue #98: Key Transition Analysis
+
     var keyTransitionTitle: String {
         ja("キー遷移分析", en: "Key Transition Analysis")
     }

--- a/Sources/KeyLensCore/AlternativeLayouts.swift
+++ b/Sources/KeyLensCore/AlternativeLayouts.swift
@@ -1,0 +1,242 @@
+// AlternativeLayouts.swift
+// Static finger/hand assignments for Colemak and Dvorak layouts (Issue #61).
+//
+// Both structs implement KeyboardLayout using output-character → (hand, finger) tables.
+// The tables are derived from the physical key positions on a standard ANSI board:
+//   a character's hand/finger is determined by WHICH PHYSICAL KEY produces it in that layout.
+//
+// Only alpha keys and common punctuation are mapped; modifier keys, numbers,
+// and function keys use the same assignments as QWERTY (not remapped by these layouts).
+//
+// Colemak と Dvorak の静的フィンガー/ハンドマップ。
+// 各文字がどの物理キー (= どの指) で打鍵されるかを表す。
+
+import CoreGraphics
+
+// MARK: - ColemakLayout
+
+/// Standard Colemak layout (17 alpha keys differ from QWERTY).
+/// Colemak 標準レイアウト (QWERTY から 17 キーが変更)。
+public struct ColemakLayout: KeyboardLayout {
+    public let name = "Colemak"
+    public init() {}
+
+    // CGKeyCode-based lookup is not used; return nil.
+    public func position(for keyCode: CGKeyCode) -> KeyPosition? { nil }
+
+    public func hand(for keyName: String) -> Hand? {
+        ColemakLayout.handTable[keyName]
+    }
+
+    public func finger(for keyName: String) -> Finger? {
+        ColemakLayout.fingerTable[keyName]
+    }
+
+    // MARK: - Hand table
+    // Keys that stay on the same hand as QWERTY are omitted and fall through to nil;
+    // callers that need a complete mapping should fall back to ANSILayout for those keys.
+    // Changed: d→L, e→R, f→L, i→R, j→R, k→R, l→R, n→R, o→R, p→L, r→L, s→L, t→L, u→R, y→R
+    public static let handTable: [String: Hand] = {
+        var t: [String: Hand] = [:]
+
+        // Left hand alpha (changed from QWERTY)
+        for k in ["d","f","p","r","s","t"] { t[k] = .left }
+        // Left hand alpha (unchanged from QWERTY)
+        for k in ["a","b","c","g","q","v","w","x","z"] { t[k] = .left }
+
+        // Right hand alpha (changed from QWERTY)
+        for k in ["e","i","j","k","l","n","o","u","y"] { t[k] = .right }
+        // Right hand alpha (unchanged from QWERTY)
+        for k in ["h","m"] { t[k] = .right }
+
+        // Number row — same as QWERTY
+        for k in ["`","1","2","3","4","5"] { t[k] = .left }
+        for k in ["6","7","8","9","0","-","="] { t[k] = .right }
+
+        // Symbol keys
+        for k in ["[","]","\\",";","'",",",".","/"] { t[k] = .right }
+
+        // Named keys
+        for k in ["Escape","Tab","CapsLock","⇧Shift","⌃Ctrl","⌥Option","⌘Cmd","Space"] { t[k] = .left }
+        for k in ["Return","Delete","⌦FwdDel","Enter(Num)"] { t[k] = .right }
+        for k in ["←","→","↑","↓"] { t[k] = .right }
+
+        return t
+    }()
+
+    // MARK: - Finger table
+    // Physical key position → output char → finger assignment in Colemak.
+    //
+    // Colemak remapping (QWERTY physical pos → Colemak output char → finger from that physical pos):
+    //   E pos (L-middle, top)  → f   (was e/L-middle)
+    //   R pos (L-index, top)   → p   (was r/L-index)
+    //   T pos (L-index, top)   → g   (was t/L-index)   same finger!
+    //   Y pos (R-index, top)   → j   (was y/R-index)   same finger!
+    //   U pos (R-index, top)   → l   (was u/R-index)   same finger!
+    //   I pos (R-middle, top)  → u   (was i/R-middle)
+    //   O pos (R-ring, top)    → y   (was o/R-ring)
+    //   S pos (L-ring, home)   → r   (was s/L-ring)    same finger!
+    //   D pos (L-middle, home) → s   (was d/L-middle)  same finger!
+    //   F pos (L-index, home)  → t   (was f/L-index)   same finger!
+    //   G pos (L-index, home)  → d   (was g/L-index)   same finger!
+    //   J pos (R-index, home)  → n   (was j/R-index)   same finger!
+    //   K pos (R-middle, home) → e   (was k/R-middle)
+    //   L pos (R-ring, home)   → i   (was l/R-ring)
+    //   ; pos (R-pinky, home)  → o   (was ;/R-pinky)
+    //   N pos (R-index, bot)   → k   (was n/R-index)   same finger!
+    public static let fingerTable: [String: Finger] = {
+        var t: [String: Finger] = [:]
+
+        // Pinky
+        for k in ["Escape","`","1","Tab","q","a","z","CapsLock","⇧Shift","⌃Ctrl","F1"] { t[k] = .pinky }
+        for k in ["0","-","=","Delete","⌦FwdDel",
+                  "[","]","\\","o","'","Return","/","←","Enter(Num)",
+                  "F10","F11","F12"] { t[k] = .pinky }
+        // Note: 'o' in Colemak is at the ';' physical key → R-pinky
+
+        // Ring
+        for k in ["2","w","r","x","F2"] { t[k] = .ring }
+        // 'r' in Colemak is at 's' physical key → L-ring
+        for k in ["9","y","i",".","→","F9"] { t[k] = .ring }
+        // 'y' at 'o' pos → R-ring; 'i' at 'l' pos → R-ring
+
+        // Middle
+        for k in ["3","f","s","c","F3"] { t[k] = .middle }
+        // 'f' at 'e' pos → L-middle; 's' at 'd' pos → L-middle
+        for k in ["8","u","e",",","↓","↑","F8"] { t[k] = .middle }
+        // 'u' at 'i' pos → R-middle; 'e' at 'k' pos → R-middle
+
+        // Index
+        for k in ["4","5","p","g","t","d","v","b","F4","F5"] { t[k] = .index }
+        // 'p' at 'r' pos → L-index; 'g' at 't' pos → L-index
+        // 't' at 'f' pos → L-index; 'd' at 'g' pos → L-index
+        for k in ["6","7","j","l","h","n","k","m","F6","F7"] { t[k] = .index }
+        // 'j' at 'y' pos → R-index; 'l' at 'u' pos → R-index
+        // 'n' at 'j' pos → R-index; 'k' at 'n' pos → R-index
+
+        // Thumb
+        for k in ["Space","⌘Cmd","⌥Option"] { t[k] = .thumb }
+
+        return t
+    }()
+}
+
+// MARK: - DvorakLayout
+
+/// Standard Dvorak Simplified Keyboard layout.
+/// Dvorak 標準レイアウト。
+public struct DvorakLayout: KeyboardLayout {
+    public let name = "Dvorak"
+    public init() {}
+
+    public func position(for keyCode: CGKeyCode) -> KeyPosition? { nil }
+
+    public func hand(for keyName: String) -> Hand? {
+        DvorakLayout.handTable[keyName]
+    }
+
+    public func finger(for keyName: String) -> Finger? {
+        DvorakLayout.fingerTable[keyName]
+    }
+
+    // MARK: - Hand table
+    // Dvorak physical layout (output char → hand):
+    //   Top row L: ' , . p y   Top row R: f g c r l
+    //   Home row L: a o e u i  Home row R: d h t n s
+    //   Bottom row L: ; q j k x  Bottom row R: b m w v z
+    public static let handTable: [String: Hand] = {
+        var t: [String: Hand] = [:]
+
+        // Left hand alpha
+        for k in ["a","e","i","j","k","o","p","q","u","x","y"] { t[k] = .left }
+        // (includes ';' as punctuation — skip for alpha-only analysis)
+
+        // Right hand alpha
+        for k in ["b","c","d","f","g","h","l","m","n","r","s","t","v","w","z"] { t[k] = .right }
+
+        // Number row — same as QWERTY
+        for k in ["`","1","2","3","4","5"] { t[k] = .left }
+        for k in ["6","7","8","9","0","-","="] { t[k] = .right }
+
+        // Symbol keys (mostly right hand in Dvorak, simplify to QWERTY convention)
+        for k in ["[","]","\\",";","'",",",".","/"] { t[k] = .right }
+
+        // Named keys
+        for k in ["Escape","Tab","CapsLock","⇧Shift","⌃Ctrl","⌥Option","⌘Cmd","Space"] { t[k] = .left }
+        for k in ["Return","Delete","⌦FwdDel","Enter(Num)"] { t[k] = .right }
+        for k in ["←","→","↑","↓"] { t[k] = .right }
+
+        return t
+    }()
+
+    // MARK: - Finger table
+    // Physical key position (QWERTY) → Dvorak output char → finger:
+    //   Q pos (L-pinky, top)   → '   (skip punctuation)
+    //   W pos (L-ring, top)    → ,   (skip punctuation)
+    //   E pos (L-middle, top)  → .   (skip punctuation)
+    //   R pos (L-index, top)   → p
+    //   T pos (L-index, top)   → y
+    //   Y pos (R-index, top)   → f
+    //   U pos (R-index, top)   → g
+    //   I pos (R-middle, top)  → c
+    //   O pos (R-ring, top)    → r
+    //   P pos (R-pinky, top)   → l
+    //   A pos (L-pinky, home)  → a
+    //   S pos (L-ring, home)   → o
+    //   D pos (L-middle, home) → e
+    //   F pos (L-index, home)  → u
+    //   G pos (L-index, home)  → i
+    //   H pos (R-index, home)  → d
+    //   J pos (R-index, home)  → h
+    //   K pos (R-middle, home) → t
+    //   L pos (R-ring, home)   → n
+    //   ; pos (R-pinky, home)  → s
+    //   Z pos (L-pinky, bot)   → ;  (skip)
+    //   X pos (L-ring, bot)    → q
+    //   C pos (L-middle, bot)  → j
+    //   V pos (L-index, bot)   → k
+    //   B pos (L-index, bot)   → x
+    //   N pos (R-index, bot)   → b
+    //   M pos (R-index, bot)   → m
+    //   , pos (R-middle, bot)  → w
+    //   . pos (R-ring, bot)    → v
+    //   / pos (R-pinky, bot)   → z
+    public static let fingerTable: [String: Finger] = {
+        var t: [String: Finger] = [:]
+
+        // Pinky
+        for k in ["Escape","`","1","Tab","a","CapsLock","⇧Shift","⌃Ctrl","F1"] { t[k] = .pinky }
+        // 'a' stays at A pos → L-pinky
+        for k in ["0","-","=","Delete","⌦FwdDel",
+                  "l","s","Return","z","←","Enter(Num)",
+                  "F10","F11","F12"] { t[k] = .pinky }
+        // 'l' at P pos → R-pinky; 's' at ; pos → R-pinky; 'z' at / pos → R-pinky
+
+        // Ring
+        for k in ["2","o","q","F2"] { t[k] = .ring }
+        // 'o' at S pos → L-ring; 'q' at X pos → L-ring
+        for k in ["9","r","n","v","→","F9"] { t[k] = .ring }
+        // 'r' at O pos → R-ring; 'n' at L pos → R-ring; 'v' at . pos → R-ring
+
+        // Middle
+        for k in ["3","e","j","F3"] { t[k] = .middle }
+        // 'e' at D pos → L-middle; 'j' at C pos → L-middle
+        for k in ["8","c","t","w","↓","↑","F8"] { t[k] = .middle }
+        // 'c' at I pos → R-middle; 't' at K pos → R-middle; 'w' at , pos → R-middle
+
+        // Index
+        for k in ["4","5","p","y","u","i","k","x","F4","F5"] { t[k] = .index }
+        // 'p' at R pos → L-index; 'y' at T pos → L-index
+        // 'u' at F pos → L-index; 'i' at G pos → L-index
+        // 'k' at V pos → L-index; 'x' at B pos → L-index
+        for k in ["6","7","f","g","d","h","b","m","F6","F7"] { t[k] = .index }
+        // 'f' at Y pos → R-index; 'g' at U pos → R-index
+        // 'd' at H pos → R-index; 'h' at J pos → R-index
+        // 'b' at N pos → R-index; 'm' at M pos → R-index
+
+        // Thumb
+        for k in ["Space","⌘Cmd","⌥Option"] { t[k] = .thumb }
+
+        return t
+    }()
+}


### PR DESCRIPTION
## Summary

- Adds a **Layout Efficiency Comparison** table to the Ergonomics tab
- Takes the user's actual all-time bigram frequencies and computes same-finger bigram rate (SFB) and hand-alternation rate for QWERTY, Colemak, and Dvorak
- The layout with the best hand-alternation rate gets a 👑 crown indicator
- No network calls or AI required — all static finger-assignment data

## Files Changed

| File | Change |
|------|--------|
| `KeyLensCore/AlternativeLayouts.swift` | **NEW** — `ColemakLayout` + `DvorakLayout` with static hand/finger tables |
| `KeyCountStore+Ergonomics.swift` | Add `layoutEfficiencyScores()` in a new extension |
| `ChartsDataTypes.swift` | Add `LayoutEfficiencyEntry` struct |
| `ChartsWindowController.swift` | Add `@Published var layoutEfficiency` + reload call |
| `Charts+ErgonomicsTab.swift` | Add `layoutEfficiencySection` comparison table |
| `L10n.swift` | Add 5 bilingual strings |

## How it works

The Colemak and Dvorak layouts define `hand(for:)` and `finger(for:)` by mapping each **output character** to the physical key position that produces it in that layout. The SFB/alternation computation then mirrors the existing logic used for the QWERTY analysis.

## Test plan

- [ ] Open Ergonomics tab → "Layout Efficiency Comparison" section appears above Key Transition Analysis
- [ ] Table shows 3 rows: QWERTY, Colemak, Dvorak with % values
- [ ] Layout with highest alternation rate has crown icon
- [ ] Help popover text appears correctly in both EN and JA
- [ ] App with no bigram data shows "No data yet" message