### PR TITLE
feat: KLE JSON import for custom heatmap layout template

### DIFF
--- a/Sources/KeyLens/KLEParser.swift
+++ b/Sources/KeyLens/KLEParser.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+// MARK: - KeyDef Codable
+
+extension KeyDef: Codable {
+    enum CodingKeys: String, CodingKey { case label, keyName, widthRatio }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            try c.decode(String.self, forKey: .label),
+            try c.decode(String.self, forKey: .keyName),
+            try c.decode(Double.self, forKey: .widthRatio)
+        )
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(label,      forKey: .label)
+        try c.encode(keyName,    forKey: .keyName)
+        try c.encode(widthRatio, forKey: .widthRatio)
+    }
+}
+
+// MARK: - KLE parse errors
+
+enum KLEParseError: LocalizedError {
+    case invalidFormat
+    case emptyLayout
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat: return L10n.shared.kleParseErrorInvalid
+        case .emptyLayout:   return L10n.shared.kleParseErrorEmpty
+        }
+    }
+}
+
+// MARK: - KLEParser
+
+/// Parses a keyboard-layout-editor.com JSON file into rows of KeyDef.
+///
+/// Supports standard, non-rotated keyboards. Each top-level JSON array element
+/// that is itself an array is treated as one keyboard row. Property-only dict
+/// elements (KLE metadata) at the top level are skipped.
+///
+/// Within a row, object elements accumulate `x` (pre-key gap) and `w` (key width)
+/// that apply to the next string element (key label). After each key is consumed,
+/// `w` resets to 1.0 and `x` resets to 0. The first `\n`-separated legend line
+/// is used as both the display label and the keyName (matched against KeyCountStore
+/// counts keys).
+struct KLEParser {
+
+    static func parse(_ data: Data) throws -> [[KeyDef]] {
+        guard let outer = try? JSONSerialization.jsonObject(with: data) as? [Any] else {
+            throw KLEParseError.invalidFormat
+        }
+
+        var rows: [[KeyDef]] = []
+
+        for element in outer {
+            // Top-level dicts are KLE metadata — skip them.
+            guard let kleRow = element as? [Any] else { continue }
+
+            var row: [KeyDef] = []
+            var pendingX: Double = 0.0  // gap to insert as spacer before next key
+            var currentW: Double = 1.0  // width of next key
+
+            for item in kleRow {
+                if let props = item as? [String: Any] {
+                    pendingX += doubleValue(props["x"])
+                    if let w = props["w"] { currentW = doubleValue(w) }
+                } else if let rawLabel = item as? String {
+                    // First legend line = primary label / keyName
+                    let firstLine = rawLabel.components(separatedBy: "\n").first ?? ""
+                    let trimmed   = firstLine.trimmingCharacters(in: .whitespaces)
+
+                    // Insert invisible spacer key for the x gap
+                    if pendingX > 0.01 {
+                        row.append(KeyDef("", "_spacer_", pendingX))
+                        pendingX = 0
+                    }
+
+                    let label   = trimmed.isEmpty ? firstLine : trimmed
+                    let keyName = trimmed.isEmpty ? "_spacer_" : trimmed
+                    row.append(KeyDef(label, keyName, currentW))
+
+                    currentW = 1.0  // reset for next key
+                    pendingX = 0
+                }
+            }
+
+            if !row.isEmpty { rows.append(row) }
+        }
+
+        if rows.isEmpty { throw KLEParseError.emptyLayout }
+        return rows
+    }
+
+    // Extract Double from Any (JSON gives Int or Double for numeric values)
+    private static func doubleValue(_ v: Any?) -> Double {
+        switch v {
+        case let d as Double: return d
+        case let i as Int:    return Double(i)
+        default:              return 0
+        }
+    }
+}

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -14,6 +14,7 @@ enum HeatmapTemplate: String, CaseIterable {
     case ansi        = "ANSI"
     case pangaea     = "Pangaea"
     case ortholinear = "Ortho"
+    case custom      = "Custom"
 }
 
 private enum HeatmapTooltipStyle {
@@ -45,7 +46,10 @@ struct KeyboardHeatmapView: View {
     @State private var showModeHelp: Bool = false
     @State private var showStrainLegendHelp: Bool = false
     @State private var copyConfirmed = false
+    @State private var showImportError = false
+    @State private var importErrorMessage = ""
     @AppStorage("heatmapTemplate") private var template: HeatmapTemplate = .ansi
+    @AppStorage("kleCustomLayoutJSON") private var kleCustomLayoutJSON: String = ""
     @ObservedObject private var theme = ThemeStore.shared
     @Environment(\.colorScheme) private var colorScheme
 
@@ -177,6 +181,16 @@ struct KeyboardHeatmapView: View {
          .init("⌘", "⌘Cmd",    1), .init("⌥", "⌥Option", 1), .init("⌃", "⌃Ctrl", 1)],
     ]
 
+    // Decodes the persisted KLE JSON string into rows of KeyDef.
+    // Returns [] when nothing has been imported yet.
+    private var customRows: [[KeyDef]] {
+        guard !kleCustomLayoutJSON.isEmpty,
+              let data = kleCustomLayoutJSON.data(using: .utf8),
+              let rows = try? JSONDecoder().decode([[KeyDef]].self, from: data)
+        else { return [] }
+        return rows
+    }
+
     // キーボードキー名をテンプレートに応じて動的に計算する（instance computed property）
     // Template-aware keyboard key names; computed per-render from active template.
     private var keyboardKeyNames: Set<String> {
@@ -188,6 +202,8 @@ struct KeyboardHeatmapView: View {
             defs = (Self.pangaeaLeftRows + Self.pangaeaRightRows).flatMap { $0 }
         case .ortholinear:
             defs = Self.ortholinearRows.flatMap { $0 }
+        case .custom:
+            defs = customRows.flatMap { $0 }
         }
         return Set(defs.map(\.keyName)).subtracting(["_spacer_"])
     }
@@ -255,8 +271,20 @@ struct KeyboardHeatmapView: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .frame(maxWidth: 200)
+                    .frame(maxWidth: 260)
+
+                    if template == .custom {
+                        Button(L10n.shared.importKLEButton, action: importKLELayout)
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                    }
+
                     Spacer()
+                }
+                .alert(L10n.shared.kleParseErrorTitle, isPresented: $showImportError) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text(importErrorMessage)
                 }
                 // Mode toggle + connected keyboard names
                 HStack {
@@ -312,7 +340,8 @@ struct KeyboardHeatmapView: View {
                 template: template,
                 keyboardKeyNames: keyboardKeyNames,
                 strainScores: strainScores,
-                selectedCellID: $selectedCellID
+                selectedCellID: $selectedCellID,
+                customRows: customRows
             )
         }
     }
@@ -326,7 +355,8 @@ struct KeyboardHeatmapView: View {
             mode: mode,
             template: template,
             keyboardKeyNames: keyboardKeyNames,
-            strainScores: strainScores
+            strainScores: strainScores,
+            customRows: customRows
         )
         .frame(width: 800) // Base width for export
         .background(Color(NSColor.windowBackgroundColor))
@@ -350,13 +380,32 @@ struct KeyboardHeatmapView: View {
     }
 
     @MainActor
+    private func importKLELayout() {
+        let panel = NSOpenPanel()
+        panel.allowedContentTypes = [.json]
+        panel.title = L10n.shared.importKLEButton
+        panel.message = L10n.shared.importKLEButton
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            let data = try Data(contentsOf: url)
+            let rows = try KLEParser.parse(data)
+            let encoded = try JSONEncoder().encode(rows)
+            kleCustomLayoutJSON = String(data: encoded, encoding: .utf8) ?? ""
+        } catch {
+            importErrorMessage = error.localizedDescription
+            showImportError = true
+        }
+    }
+
+    @MainActor
     private func copyToClipboard() {
         let view = HeatmapExportView(
             counts: counts,
             mode: mode,
             template: template,
             keyboardKeyNames: keyboardKeyNames,
-            strainScores: strainScores
+            strainScores: strainScores,
+            customRows: customRows
         )
         .frame(width: 800)
         .background(Color(NSColor.windowBackgroundColor))
@@ -384,6 +433,7 @@ struct HeatmapExportView: View {
     let keyboardKeyNames: Set<String>
     let strainScores: [String: Int]
     var selectedCellID: Binding<String?>? = nil
+    var customRows: [[KeyDef]] = []
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -401,6 +451,15 @@ struct HeatmapExportView: View {
     }
 
     private var maxStrainScore: Int { strainScores.values.max() ?? 1 }
+
+    private var activeRowCount: Int {
+        switch template {
+        case .ansi:        return KeyboardHeatmapView.ansiRows.count
+        case .pangaea:     return KeyboardHeatmapView.pangaeaLeftRows.count
+        case .ortholinear: return KeyboardHeatmapView.ortholinearRows.count
+        case .custom:      return max(customRows.count, 3)
+        }
+    }
 
     private func keyDisplayValues(for keyName: String) -> (Int, Int) {
         switch mode {
@@ -443,11 +502,24 @@ struct HeatmapExportView: View {
                                 rowView(KeyboardHeatmapView.pangaeaRightRows[i], rowID: "right-\(i)", availableWidth: halfWidth)
                             }
                         }
+                    case .custom:
+                        if customRows.isEmpty {
+                            Text(L10n.shared.kleCustomNoData)
+                                .font(.callout)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.center)
+                                .frame(maxWidth: .infinity, alignment: .center)
+                                .padding(.top, 20)
+                        } else {
+                            ForEach(Array(customRows.enumerated()), id: \.offset) { rowIndex, row in
+                                rowView(row, rowID: "custom-\(rowIndex)", availableWidth: availableWidth)
+                            }
+                        }
                     }
                 }
                 .padding(8)
             }
-            .frame(height: CGFloat(5) * (keyHeight + keySpacing) - keySpacing + 16)
+            .frame(height: CGFloat(activeRowCount) * (keyHeight + keySpacing) - keySpacing + 16)
 
             mouseSection
             legend

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -405,6 +405,29 @@ final class L10n {
         ja("コピーしました！", en: "Copied!")
     }
 
+    var importKLEButton: String {
+        ja("レイアウトをインポート…", en: "Import Layout…")
+    }
+
+    var kleParseErrorTitle: String {
+        ja("インポート失敗", en: "Import Failed")
+    }
+
+    var kleParseErrorInvalid: String {
+        ja("ファイルを KLE JSON として解析できませんでした。keyboard-layout-editor.com からエクスポートした有効な JSON ファイルを選択してください。",
+           en: "The file could not be parsed as KLE JSON. Select a valid JSON file exported from keyboard-layout-editor.com.")
+    }
+
+    var kleParseErrorEmpty: String {
+        ja("レイアウトにキーが見つかりませんでした。",
+           en: "No keys were found in the layout.")
+    }
+
+    var kleCustomNoData: String {
+        ja("カスタムレイアウトが未インポートです。\n「レイアウトをインポート…」をクリックして KLE JSON ファイルを読み込んでください。",
+           en: "No custom layout imported yet.\nClick \"Import Layout…\" to load a KLE JSON file.")
+    }
+
     var editPromptMenuItem: String {
         ja("AIプロンプトを編集…", en: "Edit AI Prompt…")
     }


### PR DESCRIPTION
## Summary

- Adds a **Custom** segment to the heatmap template picker (ANSI | Pangaea | Ortho | **Custom**)
- When **Custom** is selected, an **Import Layout…** button appears that opens an `NSOpenPanel` for selecting a `.json` file exported from [keyboard-layout-editor.com](https://keyboard-layout-editor.com)
- The parsed layout is persisted via `@AppStorage` (JSON-encoded `[[KeyDef]]`) and rendered using the existing row-based heat cell engine

## New file

- `KLEParser.swift` — parses KLE JSON array format into `[[KeyDef]]`; adds `Codable` conformance to `KeyDef` for JSON persistence

## Changed files

- `KeyboardHeatmapView.swift` — `HeatmapTemplate.custom` case, import button + `NSOpenPanel`, error alert, custom rendering path, dynamic row-height calculation
- `L10n.swift` — 5 new bilingual strings (`importKLEButton`, `kleParseErrorTitle`, `kleParseErrorInvalid`, `kleParseErrorEmpty`, `kleCustomNoData`)

## Test plan

- [ ] Select **Custom** template — "Import Layout…" button appears
- [ ] Import a valid KLE JSON file — layout renders in heatmap
- [ ] Import an invalid file — error alert appears with localized message
- [ ] Imported layout persists after closing and reopening Charts window
- [ ] Export PNG with custom layout works correctly
- [ ] Other templates (ANSI, Pangaea, Ortho) unaffected

Closes #43