### PR TITLE
feat: session detection — group keystrokes into work sessions

### DIFF
--- a/Sources/KeyLens/AppDelegate.swift
+++ b/Sources/KeyLens/AppDelegate.swift
@@ -100,6 +100,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     }
 
     func applicationWillTerminate(_ notification: Notification) {
+        // Finalize the open typing session so it is included in the flush.
+        KeyCountStore.shared.finalizeCurrentSession()
         // Flush pending keystroke data to keylens.db before exit.
         KeyCountStore.shared.flushSync()
         // Flush pending mouse distance data to mouse.db before exit.

--- a/Sources/KeyLens/Charts+ActivityTab.swift
+++ b/Sources/KeyLens/Charts+ActivityTab.swift
@@ -13,6 +13,7 @@ extension ChartsView {
                 chartSection("Hourly Distribution", helpText: L10n.shared.helpHourlyDistribution) { hourlyDistributionChart }
                 chartSection("Daily Totals", helpText: L10n.shared.helpDailyTotals) { dailyTotalsChart }
                 chartSection("Monthly Totals", helpText: L10n.shared.helpMonthlyTotals) { monthlyTotalsChart }
+                chartSection(L10n.shared.chartTitleSessions, helpText: L10n.shared.helpSessions) { sessionsChart }
             }
             .padding(24)
         }
@@ -276,6 +277,54 @@ extension ChartsView {
                 }
             }
             .frame(height: 180)
+        }
+    }
+
+    // MARK: - Issue #60: Sessions chart
+
+    @ViewBuilder
+    var sessionsChart: some View {
+        if model.sessionSummaries.isEmpty {
+            emptyState
+        } else {
+            VStack(alignment: .leading, spacing: 16) {
+                // Sessions per day (bar chart)
+                Text(L10n.shared.sessionsPerDay)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Chart(model.sessionSummaries) { item in
+                    BarMark(
+                        x: .value("Date", item.date),
+                        y: .value("Sessions", item.sessionCount)
+                    )
+                    .foregroundStyle(theme.accentColor)
+                    .cornerRadius(3)
+                }
+                .frame(height: 140)
+
+                // Longest session per day (bar chart)
+                Text(L10n.shared.longestSessionLabel)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Chart(model.sessionSummaries) { item in
+                    BarMark(
+                        x: .value("Date", item.date),
+                        y: .value("Minutes", item.longestMinutes)
+                    )
+                    .foregroundStyle(theme.accentColor.opacity(0.7))
+                    .cornerRadius(3)
+                    PointMark(
+                        x: .value("Date", item.date),
+                        y: .value("Minutes", item.avgMinutes)
+                    )
+                    .foregroundStyle(theme.accentColor)
+                    .symbolSize(30)
+                }
+                .frame(height: 140)
+                Text("● \(L10n.shared.avgSessionLabel)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -213,6 +213,19 @@ struct KeyTransitionEntry: Identifiable {
     }
 }
 
+// MARK: - Issue #60: Session detection data types
+
+/// Per-day summary of detected typing sessions.
+/// 日別タイピングセッションの集計。
+struct DailySessionSummary: Identifiable {
+    let id: String            // date key (yyyy-MM-dd)
+    let date: String
+    let sessionCount: Int
+    let totalMinutes: Double
+    let longestMinutes: Double
+    var avgMinutes: Double { sessionCount > 0 ? totalMinutes / Double(sessionCount) : 0 }
+}
+
 // MARK: - Issue #168: Mouse tab data types
 
 struct MouseDailyEntry: Identifiable {

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -58,6 +58,8 @@ final class ChartDataModel: ObservableObject {
     @Published var keyTransitionOutgoing: [KeyTransitionEntry]  = []
     // Issue #61: layout efficiency comparison — QWERTY vs Colemak vs Dvorak
     @Published var layoutEfficiency:      [LayoutEfficiencyEntry] = []
+    // Issue #60: Session detection
+    @Published var sessionSummaries:      [DailySessionSummary]   = []
     // Issue #168: Mouse tab
     @Published var mouseDailyDistances:   [MouseDailyEntry]       = []
     @Published var mouseHourlyActivity:   [MouseHourEntry]        = []
@@ -130,6 +132,8 @@ final class ChartDataModel: ObservableObject {
         fingerIKI = store.ikiPerFinger().map(FingerIKIEntry.init)
         // Issue #61: layout efficiency comparison
         layoutEfficiency = store.layoutEfficiencyScores()
+        // Issue #60: session detection
+        sessionSummaries = store.allSessionSummaries()
         // Issue #168: Mouse tab
         let ms = MouseStore.shared
         mouseDailyDistances = ms.dailyDistances().map(MouseDailyEntry.init)

--- a/Sources/KeyLens/KeyCountStore+SQLite.swift
+++ b/Sources/KeyLens/KeyCountStore+SQLite.swift
@@ -13,11 +13,20 @@ struct PendingStore {
     var hourly:        [String: [Int: Int]]    = [:]  // date → hour → delta
     var bigramIKI:     [String: (sum: Double, count: Int)] = [:]
     var ikiBuckets:    [String: [Int: Int]]    = [:]  // date → bucket → delta
+    // Issue #60: completed typing sessions waiting to be flushed to SQLite
+    var pendingSessions: [SessionRecord]       = []
+
+    struct SessionRecord {
+        var date: String        // yyyy-MM-dd of sessionStart
+        var startTime: Double   // Unix timestamp
+        var endTime: Double     // Unix timestamp
+        var keystrokeCount: Int
+    }
 
     var isEmpty: Bool {
         dailyKeys.isEmpty && dailyBigrams.isEmpty && dailyTrigrams.isEmpty &&
         dailyApps.isEmpty && dailyDevices.isEmpty && hourly.isEmpty &&
-        bigramIKI.isEmpty && ikiBuckets.isEmpty
+        bigramIKI.isEmpty && ikiBuckets.isEmpty && pendingSessions.isEmpty
     }
 }
 
@@ -96,6 +105,17 @@ extension KeyCountStore {
                     t.column("count", .integer).notNull().defaults(to: 0)
                     t.primaryKey(["date", "bucket"])
                 }
+            }
+            // Issue #60: typing session records
+            migrator.registerMigration("v2") { db in
+                try db.create(table: "sessions", ifNotExists: true) { t in
+                    t.autoIncrementedPrimaryKey("id")
+                    t.column("date", .text).notNull()
+                    t.column("start_time", .double).notNull()
+                    t.column("end_time", .double).notNull()
+                    t.column("keystroke_count", .integer).notNull().defaults(to: 0)
+                }
+                try db.create(index: "sessions_date_idx", on: "sessions", columns: ["date"], ifNotExists: true)
             }
             try migrator.migrate(db)
 
@@ -186,6 +206,13 @@ extension KeyCountStore {
                             """, arguments: [date, bucket, delta])
                     }
                 }
+                // Issue #60: flush completed typing sessions
+                for s in p.pendingSessions where s.endTime > s.startTime && s.keystrokeCount > 0 {
+                    try db.execute(sql: """
+                        INSERT INTO sessions (date, start_time, end_time, keystroke_count)
+                        VALUES (?, ?, ?, ?)
+                        """, arguments: [s.date, s.startTime, s.endTime, s.keystrokeCount])
+                }
             }
         } catch {
             pending = mergePending(p, into: pending)
@@ -211,6 +238,7 @@ extension KeyCountStore {
             r.bigramIKI[bigram] = (e.sum + sum, e.count + cnt)
         }
         for (d, bkts) in source.ikiBuckets { for (b,v) in bkts { r.ikiBuckets[d, default:[:]][b, default:0] += v } }
+        r.pendingSessions.append(contentsOf: source.pendingSessions)
         return r
     }
 }
@@ -279,6 +307,39 @@ extension KeyCountStore {
                     percentage: total > 0 ? Double(buckets[i]) / Double(total) * 100.0 : 0
                 )
             }
+        }
+    }
+}
+
+// MARK: - Issue #60: Session query
+
+extension KeyCountStore {
+
+    /// Returns per-day session summaries (count, total minutes, longest session) from SQLite.
+    /// Must NOT be called on `queue` to avoid deadlock.
+    func allSessionSummaries() -> [DailySessionSummary] {
+        guard let db = dbQueue else { return [] }
+        let rows = (try? db.read { db in
+            try Row.fetchAll(db, sql: """
+                SELECT date,
+                       COUNT(*) AS session_count,
+                       SUM(end_time - start_time) / 60.0 AS total_minutes,
+                       MAX(end_time - start_time) / 60.0 AS longest_minutes
+                FROM sessions
+                WHERE end_time > start_time AND keystroke_count > 0
+                GROUP BY date
+                ORDER BY date
+                """)
+        }) ?? []
+        return rows.map { row in
+            let date: String = row["date"]
+            return DailySessionSummary(
+                id: date,
+                date: date,
+                sessionCount: row["session_count"],
+                totalMinutes: row["total_minutes"] ?? 0,
+                longestMinutes: row["longest_minutes"] ?? 0
+            )
         }
     }
 }

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -186,6 +186,12 @@ final class KeyCountStore {
     var wpmSessionStart: Date? = nil
     var wpmSessionKeystrokes: Int = 0
 
+    // Typing session detection (Issue #60). All access on `queue`.
+    // A session boundary is defined as a gap of ≥ sessionGapThreshold with no keystrokes.
+    static let sessionGapThreshold: TimeInterval = 5 * 60  // 5 minutes
+    private var currentSessionStart: Date? = nil
+    private var currentSessionKeystrokes: Int = 0
+
     private init() {
         let dir = FileManager.default
             .urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -261,6 +267,24 @@ final class KeyCountStore {
             _todayCount += 1
 
             let prevInputTime = store.lastInputTime
+
+            // Session detection (Issue #60): detect ≥5-min gaps and record completed sessions.
+            if let prev = prevInputTime {
+                let gap = timestamp.timeIntervalSince(prev)
+                if gap >= Self.sessionGapThreshold {
+                    // Gap is large enough to close the current session and start a new one.
+                    finalizeCurrentSessionLocked(at: prev)
+                    currentSessionStart = timestamp
+                    currentSessionKeystrokes = 1
+                } else {
+                    if currentSessionStart == nil { currentSessionStart = timestamp }
+                    currentSessionKeystrokes += 1
+                }
+            } else {
+                // First keystroke ever recorded.
+                currentSessionStart = timestamp
+                currentSessionKeystrokes = 1
+            }
 
             // Welford IKI update (≤1000ms only)
             if let last = store.lastInputTime {
@@ -390,6 +414,32 @@ final class KeyCountStore {
         scheduleSave()
     }
 
+    // MARK: - Session management (Issue #60)
+
+    /// Finalize the in-progress session and add it to pending. Must be called on `queue`.
+    func finalizeCurrentSessionLocked(at endTime: Date) {
+        guard let start = currentSessionStart,
+              currentSessionKeystrokes > 0,
+              endTime.timeIntervalSince(start) > 0 else { return }
+        let date = Self.dayFormatter.string(from: start)
+        pending.pendingSessions.append(PendingStore.SessionRecord(
+            date: date,
+            startTime: start.timeIntervalSince1970,
+            endTime: endTime.timeIntervalSince1970,
+            keystrokeCount: currentSessionKeystrokes
+        ))
+        currentSessionStart = nil
+        currentSessionKeystrokes = 0
+    }
+
+    /// Finalize the open session and flush it. Call from AppDelegate on termination.
+    func finalizeCurrentSession() {
+        queue.sync {
+            guard let last = store.lastInputTime else { return }
+            finalizeCurrentSessionLocked(at: last)
+        }
+    }
+
     // MARK: - Metadata
 
     var totalCount: Int {
@@ -409,6 +459,8 @@ final class KeyCountStore {
             secondLastKeyName = nil
             alternationStreak = 0
             lastBigramWasHighStrain = false
+            currentSessionStart = nil
+            currentSessionKeystrokes = 0
             // Re-prime today cache
             _todayCacheDate = todayKey
             _todayCount = dailyTotalLocked(for: _todayCacheDate)
@@ -424,6 +476,8 @@ final class KeyCountStore {
             secondLastKeyName = nil
             alternationStreak = 0
             lastBigramWasHighStrain = false
+            currentSessionStart = nil
+            currentSessionKeystrokes = 0
             _todayCount = 0
             _todayCacheDate = todayKey
             // Clear SQLite tables
@@ -431,7 +485,7 @@ final class KeyCountStore {
                 try? db.write { db in
                     for table in ["daily_keys","daily_bigrams","daily_trigrams",
                                   "daily_apps","daily_devices","hourly_counts",
-                                  "bigram_iki","iki_buckets"] {
+                                  "bigram_iki","iki_buckets","sessions"] {
                         try db.execute(sql: "DELETE FROM \(table)")
                     }
                 }

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1055,6 +1055,31 @@ final class L10n {
         )
     }
 
+    // MARK: - Issue #60: Session detection
+
+    var chartTitleSessions: String {
+        ja("セッション", en: "Sessions")
+    }
+
+    var helpSessions: String {
+        ja(
+            "5分以上キー入力がなかった場合にセッションの区切りとして検出します。セッション数・最長セッション時間・平均セッション時間を日別に表示します。",
+            en: "A session boundary is detected when there is no keystroke for 5 or more minutes. Shows daily session count, longest session duration, and average session duration."
+        )
+    }
+
+    var sessionsPerDay: String {
+        ja("日別セッション数", en: "Sessions per Day")
+    }
+
+    var longestSessionLabel: String {
+        ja("最長セッション (分)", en: "Longest Session (min)")
+    }
+
+    var avgSessionLabel: String {
+        ja("平均セッション (分)", en: "Avg Session (min)")
+    }
+
     // MARK: - Chart Theme
 
     var chartThemeMenuTitle: String { ja("チャートテーマ", en: "Chart Theme") }


### PR DESCRIPTION
## Summary

- Detects typing sessions by identifying gaps of ≥ 5 minutes with no keystrokes
- Stores completed sessions in a new `sessions` SQLite table (added via GRDB migration `v2`)
- Shows a **Sessions** chart section in the Activity tab: sessions per day (bar) + longest/avg session duration (bar + point)

## Changes

- `KeyCountStore+SQLite.swift` — new `sessions` table migration, pending session flush, `allSessionSummaries()` query
- `KeyCountStore.swift` — in-memory session state; detects gaps in `increment()`; `finalizeCurrentSession()` called on app quit
- `AppDelegate.swift` — calls `finalizeCurrentSession()` before `flushSync()` on termination
- `ChartsDataTypes.swift` — `DailySessionSummary` struct
- `ChartsWindowController.swift` — `sessionSummaries` published property, loaded in `reload()`
- `Charts+ActivityTab.swift` — `sessionsChart` view in the Activity tab
- `L10n.swift` — bilingual strings for all new UI text

## Test plan

- [ ] Build succeeds (`./build.sh --install`)
- [ ] Type for a few minutes, quit, relaunch → Sessions chart shows at least one session
- [ ] Stop typing for 5+ min, resume, quit → two separate sessions appear
- [ ] Reset all counts → sessions table is cleared