### PR TITLE
feat: add configurable global hotkey for Keystroke Overlay

### DIFF
--- a/Sources/KeyLens/KeyboardMonitor.swift
+++ b/Sources/KeyLens/KeyboardMonitor.swift
@@ -215,6 +215,11 @@ extension KeyboardMonitor {
             DispatchQueue.main.async { WPMHotkeyManager.shared.toggle() }
         }
 
+        // Check Overlay hotkey (Issue #179)
+        if type == .keyDown, OverlayHotkeyManager.shared.matches(event: event) {
+            OverlayHotkeyManager.shared.toggle()
+        }
+
         let now = Date()
         let appName = NSWorkspace.shared.frontmostApplication?.localizedName
         let result = KeyCountStore.shared.increment(key: name, at: now, appName: appName)

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -300,6 +300,18 @@ final class L10n {
         ja("キーコードを表示", en: "Show Key Code")
     }
 
+    var overlaySettingsShortcut: String {
+        ja("ショートカット", en: "Shortcut")
+    }
+
+    var overlaySettingsChangeShortcut: String {
+        ja("ショートカットを変更", en: "Change Shortcut")
+    }
+
+    var overlaySettingsRecording: String {
+        ja("キーを押してください…", en: "Press a key…")
+    }
+
     var avgIntervalFormat: String {
         ja("平均間隔: %.0f ms", en: "Avg interval: %.0f ms")
     }

--- a/Sources/KeyLens/MenuView.swift
+++ b/Sources/KeyLens/MenuView.swift
@@ -231,6 +231,12 @@ private struct OverlayRow: View {
             }
             .buttonStyle(.plain)
 
+            // Hotkey badge
+            Text(OverlayHotkeyManager.shared.displayString)
+                .font(.system(size: 10))
+                .foregroundColor(.secondary)
+                .padding(.trailing, 4)
+
             // ギアボタン：チェックマークの左、ホバー時のみ表示
             Button(action: { appDelegate.showOverlaySettings() }) {
                 Image(systemName: "gearshape")

--- a/Sources/KeyLens/OverlayHotkeyManager.swift
+++ b/Sources/KeyLens/OverlayHotkeyManager.swift
@@ -1,0 +1,96 @@
+import AppKit
+import KeyLensCore
+
+/// Manages the global hotkey for toggling the Keystroke Overlay (Issue #179).
+///
+/// The hotkey is checked inside the existing CGEventTap (KeyboardMonitor)
+/// to avoid requiring an additional global event monitor.
+/// Default hotkey: ⌃⌥O (Control+Option+O).
+final class OverlayHotkeyManager {
+    static let shared = OverlayHotkeyManager()
+
+    private static let keyCodeKey   = "overlayHotkeyKeyCode"
+    private static let modifiersKey = "overlayHotkeyModifiers"
+
+    // Default: ⌃⌥O
+    private static let defaultKeyCode: UInt16 = 31  // 'o'
+    private static let defaultModifiers: CGEventFlags = [.maskControl, .maskAlternate]
+
+    var keyCode: UInt16 {
+        get {
+            let v = UserDefaults.standard.integer(forKey: Self.keyCodeKey)
+            return v > 0 ? UInt16(v) : Self.defaultKeyCode
+        }
+        set { UserDefaults.standard.set(Int(newValue), forKey: Self.keyCodeKey) }
+    }
+
+    var modifierFlags: CGEventFlags {
+        get {
+            let v = UserDefaults.standard.integer(forKey: Self.modifiersKey)
+            return v != 0 ? CGEventFlags(rawValue: UInt64(v)) : Self.defaultModifiers
+        }
+        set { UserDefaults.standard.set(Int(newValue.rawValue), forKey: Self.modifiersKey) }
+    }
+
+    private init() {}
+
+    // MARK: - Hotkey matching
+
+    /// Returns true if the given CGEvent matches the configured hotkey.
+    func matches(event: CGEvent) -> Bool {
+        let code = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
+        guard code == keyCode else { return false }
+        let relevant: CGEventFlags = [.maskControl, .maskAlternate, .maskShift, .maskCommand]
+        return event.flags.intersection(relevant) == modifierFlags.intersection(relevant)
+    }
+
+    // MARK: - Toggle
+
+    /// Toggles the Keystroke Overlay on/off.
+    func toggle() {
+        DispatchQueue.main.async {
+            guard let delegate = NSApp.delegate as? AppDelegate else { return }
+            delegate.toggleOverlay()
+        }
+    }
+
+    // MARK: - Display
+
+    /// Human-readable hotkey string, e.g. "⌃⌥O".
+    var displayString: String {
+        var s = ""
+        let f = modifierFlags
+        if f.contains(.maskControl)   { s += "⌃" }
+        if f.contains(.maskAlternate) { s += "⌥" }
+        if f.contains(.maskShift)     { s += "⇧" }
+        if f.contains(.maskCommand)   { s += "⌘" }
+        s += KeyboardMonitor.keyName(for: keyCode).uppercased()
+        return s
+    }
+
+    // MARK: - Hotkey recording
+
+    /// Records the next key event from a local NSEvent monitor and saves it as the new hotkey.
+    /// Calls `completion` on the main thread when done.
+    func recordNextHotkey(completion: @escaping (String) -> Void) {
+        var monitor: Any?
+        monitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
+            guard let self else { return event }
+            let relevant = NSEvent.ModifierFlags([.control, .option, .shift, .command])
+            guard !event.modifierFlags.intersection(relevant).isEmpty else { return event }
+
+            self.keyCode = event.keyCode
+
+            var cgFlags = CGEventFlags()
+            if event.modifierFlags.contains(.control) { cgFlags.insert(.maskControl) }
+            if event.modifierFlags.contains(.option)  { cgFlags.insert(.maskAlternate) }
+            if event.modifierFlags.contains(.shift)   { cgFlags.insert(.maskShift) }
+            if event.modifierFlags.contains(.command) { cgFlags.insert(.maskCommand) }
+            self.modifierFlags = cgFlags
+
+            if let m = monitor { NSEvent.removeMonitor(m) }
+            DispatchQueue.main.async { completion(self.displayString) }
+            return nil  // consume the event
+        }
+    }
+}

--- a/Sources/KeyLens/OverlaySettingsController.swift
+++ b/Sources/KeyLens/OverlaySettingsController.swift
@@ -90,6 +90,8 @@ extension Notification.Name {
 
 struct OverlaySettingsView: View {
     @State private var config: OverlayConfig = .current
+    @State private var hotkeyLabel: String = OverlayHotkeyManager.shared.displayString
+    @State private var isRecording: Bool = false
     @StateObject private var previewVM: OverlayViewModel = {
         let vm = OverlayViewModel()
         vm.keys = [
@@ -109,12 +111,13 @@ struct OverlaySettingsView: View {
                 positionSection
                 fadeDelaySection
                 sizeAndCodeSection
+                shortcutSection
                 appearanceSection
                 previewSection
             }
             .padding(20)
         }
-        .frame(width: 380, height: 500)
+        .frame(width: 380, height: 560)
         .onChange(of: config) { newConfig in
             newConfig.save()
             previewVM.config = newConfig
@@ -256,6 +259,28 @@ struct OverlaySettingsView: View {
         }
     }
 
+    private var shortcutSection: some View {
+        let l = L10n.shared
+        return GroupBox(label: Text(l.overlaySettingsShortcut).fontWeight(.medium)) {
+            HStack {
+                Text(isRecording ? l.overlaySettingsRecording : hotkeyLabel)
+                    .font(.system(size: 13, design: .monospaced))
+                    .foregroundStyle(isRecording ? Color.accentColor : Color.primary)
+                    .frame(minWidth: 60, alignment: .leading)
+                Spacer()
+                Button(isRecording ? l.overlaySettingsRecording : l.overlaySettingsChangeShortcut) {
+                    isRecording = true
+                    OverlayHotkeyManager.shared.recordNextHotkey { newLabel in
+                        hotkeyLabel = newLabel
+                        isRecording = false
+                    }
+                }
+                .disabled(isRecording)
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
     private var previewSection: some View {
         let l = L10n.shared
         return GroupBox(label: Text(l.overlaySettingsPreview).fontWeight(.medium)) {
@@ -284,7 +309,7 @@ final class OverlaySettingsController: NSWindowController {
         let window = NSWindow(contentViewController: hostVC)
         window.title = L10n.shared.overlaySettingsWindowTitle
         window.styleMask = [.titled, .closable]
-        window.setContentSize(NSSize(width: 380, height: 500))
+        window.setContentSize(NSSize(width: 380, height: 560))
         window.center()
         window.setFrameAutosaveName("OverlaySettingsWindow")
         super.init(window: window)


### PR DESCRIPTION
## Summary

- New `OverlayHotkeyManager` (mirrors `WPMHotkeyManager`) with default hotkey **⌃⌥O**, persisted in `UserDefaults`
- Hotkey is checked inside the existing CGEventTap in `KeyboardMonitor` — no extra global monitor needed
- Hotkey badge (e.g. `⌃⌥O`) displayed in `OverlayRow` in the menu, beside the gear icon
- "Change Shortcut" button in Overlay Settings window lets the user record a new hotkey

## Test plan

- [ ] Press ⌃⌥O → overlay toggles on/off from any app
- [ ] Open gear → Overlay Settings → "Change Shortcut" → press new combo → badge updates in menu
- [ ] Restart app → custom hotkey is remembered
- [ ] Default hotkey `⌃⌥O` shown in menu row beside gear icon

Closes #179