### PR TITLE
feat: add Training tab UI for bigram drill sessions (#90)

### DIFF
--- a/Sources/KeyLens/Charts+TrainingTab.swift
+++ b/Sources/KeyLens/Charts+TrainingTab.swift
@@ -1,0 +1,196 @@
+import SwiftUI
+import KeyLensCore
+
+extension ChartsView {
+
+    // MARK: - Training Tab
+
+    var trainingTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                chartSection(L10n.shared.trainingTargetsTitle,
+                             helpText: L10n.shared.helpTrainingTargets) {
+                    trainingTargetsSection
+                }
+                chartSection(L10n.shared.practiceDrillsTitle,
+                             helpText: L10n.shared.helpPracticeDrills) {
+                    practiceDrillsSection
+                }
+            }
+            .padding(24)
+        }
+    }
+
+    // MARK: - Targets
+
+    @ViewBuilder
+    private var trainingTargetsSection: some View {
+        if let session = model.trainingSession, !session.targets.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header row
+                HStack(spacing: 0) {
+                    Text(L10n.shared.trainingColumnBigram)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 80, alignment: .leading)
+                    Text(L10n.shared.trainingColumnIKI)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 120, alignment: .trailing)
+                    Text(L10n.shared.trainingColumnCount)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 90, alignment: .trailing)
+                    Text(L10n.shared.trainingColumnTier)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 70, alignment: .trailing)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+
+                Divider()
+
+                ForEach(Array(session.targets.enumerated()), id: \.offset) { index, score in
+                    let tier = tierLabel(rank: index, config: session.config)
+                    HStack(spacing: 0) {
+                        Text(displayBigram(score.bigram))
+                            .font(.system(.body, design: .monospaced))
+                            .frame(width: 80, alignment: .leading)
+                        Text(String(format: "%.0f ms", score.meanIKI))
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(ikiColor(score.meanIKI))
+                            .frame(width: 120, alignment: .trailing)
+                        Text("\(score.count)")
+                            .font(.system(.body, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 90, alignment: .trailing)
+                        Text(tier.label)
+                            .font(.caption)
+                            .padding(.horizontal, 6).padding(.vertical, 2)
+                            .background(tier.color.opacity(0.15))
+                            .foregroundStyle(tier.color)
+                            .clipShape(Capsule())
+                            .frame(width: 70, alignment: .trailing)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(index.isMultiple(of: 2) ? Color.clear : Color.primary.opacity(0.03))
+                }
+
+                Divider().padding(.top, 4)
+
+                Button(L10n.shared.trainingRegenerateButton) {
+                    model.reload()
+                }
+                .buttonStyle(.bordered)
+                .padding(.top, 10)
+            }
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(L10n.shared.trainingNoData)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+                Button(L10n.shared.trainingRegenerateButton) {
+                    model.reload()
+                }
+                .buttonStyle(.bordered)
+            }
+        }
+    }
+
+    // MARK: - Drills
+
+    @ViewBuilder
+    private var practiceDrillsSection: some View {
+        if let session = model.trainingSession, !session.drills.isEmpty {
+            VStack(alignment: .leading, spacing: 16) {
+                ForEach(Array(session.drills.enumerated()), id: \.offset) { index, drill in
+                    DrillRowView(index: index + 1, drill: drill)
+                }
+            }
+        } else {
+            emptyState
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func displayBigram(_ key: String) -> String {
+        let parts = key.components(separatedBy: "→")
+        guard parts.count == 2 else { return key }
+        return parts[0] + parts[1]
+    }
+
+    private func ikiColor(_ iki: Double) -> Color {
+        switch iki {
+        case ..<100:  return .green
+        case ..<180:  return .primary
+        default:      return .orange
+        }
+    }
+
+    private struct TierInfo {
+        let label: String
+        let color: Color
+    }
+
+    private func tierLabel(rank: Int, config: SessionConfig) -> TierInfo {
+        if rank < config.highTierSize {
+            return TierInfo(label: L10n.shared.trainingTierHigh, color: .red)
+        } else if rank < config.highTierSize + config.midTierSize {
+            return TierInfo(label: L10n.shared.trainingTierMid, color: .orange)
+        } else {
+            return TierInfo(label: L10n.shared.trainingTierLow, color: .blue)
+        }
+    }
+}
+
+// MARK: - DrillRowView
+
+private struct DrillRowView: View {
+    let index: Int
+    let drill: DrillSequence
+
+    @State private var copied = false
+
+    var kindLabel: String {
+        drill.kind == .repeated
+            ? L10n.shared.trainingDrillRepeated
+            : L10n.shared.trainingDrillAlternating
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text("\(index).")
+                    .font(.caption).foregroundStyle(.secondary)
+                Text(drill.targets.joined(separator: " + "))
+                    .font(.caption.bold())
+                Text("— \(kindLabel)")
+                    .font(.caption).foregroundStyle(.secondary)
+
+                Spacer()
+
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(drill.text, forType: .string)
+                    copied = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) { copied = false }
+                } label: {
+                    Image(systemName: copied ? "checkmark" : "clipboard")
+                        .font(.caption)
+                        .foregroundStyle(copied ? .green : .secondary)
+                }
+                .buttonStyle(.plain)
+                .help("Copy drill text")
+                .animation(.easeInOut(duration: 0.2), value: copied)
+            }
+
+            Text(drill.text)
+                .font(.system(.title3, design: .monospaced))
+                .foregroundStyle(.primary)
+                .textSelection(.enabled)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(Color.primary.opacity(0.05))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        }
+    }
+}

--- a/Sources/KeyLens/ChartsComponents.swift
+++ b/Sources/KeyLens/ChartsComponents.swift
@@ -38,6 +38,7 @@ enum ChartTab: String, CaseIterable, Identifiable {
     case shortcuts   = "Shortcuts"
     case apps        = "Apps"
     case mouse       = "Mouse"
+    case training    = "Training"
 
     var id: String { rawValue }
 
@@ -51,6 +52,7 @@ enum ChartTab: String, CaseIterable, Identifiable {
         case .shortcuts:  return "command"
         case .apps:       return "app.badge"
         case .mouse:      return "cursorarrow.motionlines"
+        case .training:   return "figure.run"
         }
     }
 }

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -78,6 +78,10 @@ struct ChartsView: View {
             mouseTab
                 .tabItem { Label(ChartTab.mouse.rawValue, systemImage: ChartTab.mouse.icon) }
                 .tag(ChartTab.mouse)
+
+            trainingTab
+                .tabItem { Label(ChartTab.training.rawValue, systemImage: ChartTab.training.icon) }
+                .tag(ChartTab.training)
         }
         .padding(.top, 8)
         .frame(minWidth: 680, minHeight: 480)

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -67,6 +67,8 @@ final class ChartDataModel: ObservableObject {
     @Published var mouseDailyDirectionEntries: [MouseDailyDirectionEntry]   = []
     // Issue #182: Mouse vs Keyboard balance
     @Published var mouseKeyboardBalance:       [MouseKeyboardBalanceEntry]  = []
+    // Issue #90: Training session derived from ranked bigrams
+    @Published var trainingSession:            TrainingSession?              = nil
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -160,6 +162,9 @@ final class ChartDataModel: ObservableObject {
             return MouseKeyboardBalanceEntry(id: entry.date, date: entry.date,
                                              distancePts: entry.distancePts, keystrokes: keys)
         }.sorted { $0.date < $1.date }
+        // Issue #90: Training session
+        let trainingScores = store.rankedBigramsForTraining(minCount: 5, topK: 10)
+        trainingSession = trainingScores.isEmpty ? nil : SessionBuilder.build(from: trainingScores)
     }
 
     /// Reloads key transition data for the given target key (Issue #98).

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1213,6 +1213,45 @@ final class L10n {
         ja("平均セッション (分)", en: "Avg Session (min)")
     }
 
+    // MARK: - Training Tab
+
+    var trainingTargetsTitle: String {
+        ja("練習対象バイグラム", en: "Training Targets")
+    }
+
+    var practiceDrillsTitle: String {
+        ja("ドリル", en: "Practice Drills")
+    }
+
+    var helpTrainingTargets: String {
+        ja("打鍵速度が遅く頻出するバイグラムを優先度スコア順に表示します。スコア = 平均IKI × log2(出現回数 + 1)。",
+           en: "Bigrams ranked by training priority: score = mean IKI × log2(count + 1). Slower and more frequent combinations rank higher.")
+    }
+
+    var helpPracticeDrills: String {
+        ja("生成されたドリルを上から順に打鍵してください。高優先度のバイグラムほど多くの繰り返しが割り当てられます。",
+           en: "Type each drill line from top to bottom. High-priority bigrams get more repetitions.")
+    }
+
+    var trainingNoData: String {
+        ja("データ不足 — 各バイグラムに5回以上の入力が必要です。",
+           en: "Not enough data — bigrams need at least 5 observations each.")
+    }
+
+    var trainingColumnBigram: String  { ja("バイグラム", en: "Bigram") }
+    var trainingColumnIKI: String     { ja("平均 IKI (ms)", en: "Avg IKI (ms)") }
+    var trainingColumnCount: String   { ja("出現回数", en: "Count") }
+    var trainingColumnTier: String    { ja("優先度", en: "Priority") }
+
+    var trainingTierHigh: String  { ja("高", en: "High") }
+    var trainingTierMid: String   { ja("中", en: "Mid") }
+    var trainingTierLow: String   { ja("低", en: "Low") }
+
+    var trainingDrillRepeated: String    { ja("繰り返し", en: "Repeated") }
+    var trainingDrillAlternating: String { ja("交互", en: "Alternating") }
+
+    var trainingRegenerateButton: String { ja("セッションを更新", en: "New Session") }
+
     // MARK: - Chart Axis Labels
 
     var axisLabelKeys: String     { ja("キー数", en: "Keys") }


### PR DESCRIPTION
## Summary

- Adds a **Training** tab to the Charts window
- **Training Targets** section: lists top bigrams ranked by priority score, with avg IKI (color-coded), count, and tier badge (High/Mid/Low)
- **Practice Drills** section: shows each generated drill as a monospaced text block the user can read and type; each drill is copyable with one click
- **New Session** button triggers a data reload to refresh the session
- All strings go through `L10n` (English + Japanese)

## Backend wired up

- `ChartDataModel.trainingSession` populated via `rankedBigramsForTraining()` → `SessionBuilder.build()`
- Builds on `DrillGenerator` (#83), `SessionBuilder` (#86), and `PracticeSequenceGenerator` (#87)

## Test plan

- [ ] Open Charts window → Training tab is visible with `figure.run` icon
- [ ] With real typing data: targets table shows bigrams with IKI and tier labels
- [ ] Drill text blocks display in monospaced font, copyable via clipboard button
- [ ] With no data: empty state message shown
- [ ] "New Session" button reloads data
- [ ] Both English and Japanese UI strings display correctly