### PR TITLE
feat: persist training session results and show history (#88)

### DIFF
--- a/Sources/KeyLens/Charts+TrainingTab.swift
+++ b/Sources/KeyLens/Charts+TrainingTab.swift
@@ -23,6 +23,10 @@ extension ChartsView {
                              helpText: L10n.shared.helpPracticeDrills) {
                     practiceDrillsSection
                 }
+                chartSection(L10n.shared.trainingHistoryTitle,
+                             helpText: L10n.shared.helpTrainingHistory) {
+                    trainingHistorySection
+                }
             }
             .padding(24)
         }
@@ -104,9 +108,23 @@ extension ChartsView {
             if let session = currentTrainingSession, !session.drills.isEmpty {
                 InteractivePracticeView(
                     session: session,
+                    sessionLengthName: sessionLength.rawValue,
                     onNewSession: {
                         model.reload()
                         trainingResetToken = UUID()
+                    },
+                    onSessionComplete: { result in
+                        KeyCountStore.shared.saveTrainingResult(
+                            targets: result.targets,
+                            sessionLength: result.sessionLength,
+                            accuracy: result.accuracy,
+                            wpm: result.wpm,
+                            duration: result.duration,
+                            totalTyped: result.totalTyped,
+                            totalCorrect: result.totalCorrect
+                        ) {
+                            model.reload()
+                        }
                     }
                 )
                 // Reset interactive state when length or "New Session" changes.
@@ -115,6 +133,82 @@ extension ChartsView {
                 emptyState
             }
         }
+    }
+
+    // MARK: - History
+
+    @ViewBuilder
+    private var trainingHistorySection: some View {
+        if model.trainingHistory.isEmpty {
+            Text(L10n.shared.trainingHistoryEmpty)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 50, alignment: .center)
+        } else {
+            VStack(alignment: .leading, spacing: 0) {
+                // Header
+                HStack(spacing: 0) {
+                    Text(L10n.shared.trainingHistoryDate)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 140, alignment: .leading)
+                    Text(L10n.shared.trainingHistoryTargets)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 120, alignment: .leading)
+                    Text(L10n.shared.trainingHistoryLength)
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 70, alignment: .leading)
+                    Text(L10n.shared.trainingColumnIKI.components(separatedBy: " ").first ?? "Acc")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 60, alignment: .trailing)
+                        .help("Accuracy %")
+                    Text("WPM")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 55, alignment: .trailing)
+                    Text("Time")
+                        .font(.caption).foregroundStyle(.secondary)
+                        .frame(width: 55, alignment: .trailing)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+
+                Divider()
+
+                ForEach(Array(model.trainingHistory.enumerated()), id: \.element.id) { index, record in
+                    HStack(spacing: 0) {
+                        Text(formatDate(record.completedAt))
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 140, alignment: .leading)
+                        Text(record.targetDisplayStrings.joined(separator: " "))
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(width: 120, alignment: .leading)
+                        Text(record.sessionLength)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(width: 70, alignment: .leading)
+                        Text("\(record.accuracy)%")
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(record.accuracy >= 90 ? .green : record.accuracy >= 70 ? .orange : .red)
+                            .frame(width: 60, alignment: .trailing)
+                        Text("\(record.wpm)")
+                            .font(.system(.caption, design: .monospaced))
+                            .frame(width: 55, alignment: .trailing)
+                        Text(String(format: "%.0fs", record.durationSeconds))
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 55, alignment: .trailing)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(index.isMultiple(of: 2) ? Color.clear : Color.primary.opacity(0.03))
+                }
+            }
+        }
+    }
+
+    private func formatDate(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MM/dd HH:mm"
+        return f.string(from: date)
     }
 
     // MARK: - Helpers
@@ -151,9 +245,21 @@ extension ChartsView {
 
 // MARK: - InteractivePracticeView
 
+struct TrainingCompletionResult {
+    let targets: [String]
+    let sessionLength: String
+    let accuracy: Int
+    let wpm: Int
+    let duration: Double
+    let totalTyped: Int
+    let totalCorrect: Int
+}
+
 private struct InteractivePracticeView: View {
     let session: TrainingSession
+    let sessionLengthName: String
     let onNewSession: () -> Void
+    let onSessionComplete: (TrainingCompletionResult) -> Void
 
     // results[i] = true/false for each character typed in the current drill.
     // results.count is always equal to the current cursor position.
@@ -318,8 +424,20 @@ private struct InteractivePracticeView: View {
             drillIndex += 1
             results = []
         } else {
-            sessionDuration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+            let duration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+            sessionDuration = duration
             sessionComplete = true
+            let pct = totalTyped > 0 ? Int(Double(totalCorrect) / Double(totalTyped) * 100) : 0
+            let wpm = duration > 0 ? Int(Double(totalTyped) / 5.0 / (duration / 60.0)) : 0
+            onSessionComplete(TrainingCompletionResult(
+                targets: session.targets.map { $0.bigram },
+                sessionLength: sessionLengthName,
+                accuracy: pct,
+                wpm: wpm,
+                duration: duration,
+                totalTyped: totalTyped,
+                totalCorrect: totalCorrect
+            ))
         }
     }
 }

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -69,6 +69,8 @@ final class ChartDataModel: ObservableObject {
     @Published var mouseKeyboardBalance:       [MouseKeyboardBalanceEntry]  = []
     // Issue #90: Ranked bigrams for training — session is built in the view using the user's length preference.
     @Published var trainingScores:             [BigramScore]                 = []
+    // Issue #88: Training result history
+    @Published var trainingHistory:            [TrainingRecord]              = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -164,6 +166,8 @@ final class ChartDataModel: ObservableObject {
         }.sorted { $0.date < $1.date }
         // Issue #90: Training — store raw scores; session is built in the view with the user's length config.
         trainingScores = store.rankedBigramsForTraining(minCount: 5, topK: 10)
+        // Issue #88: Training history
+        trainingHistory = store.trainingHistory(limit: 20)
     }
 
     /// Reloads key transition data for the given target key (Issue #98).

--- a/Sources/KeyLens/KeyCountStore+SQLite.swift
+++ b/Sources/KeyLens/KeyCountStore+SQLite.swift
@@ -117,6 +117,22 @@ extension KeyCountStore {
                 }
                 try db.create(index: "sessions_date_idx", on: "sessions", columns: ["date"], ifNotExists: true)
             }
+            // Issue #88: training result history
+            migrator.registerMigration("v3") { db in
+                try db.create(table: "training_results", ifNotExists: true) { t in
+                    t.autoIncrementedPrimaryKey("id")
+                    t.column("completed_at", .double).notNull()
+                    t.column("targets", .text).notNull()          // JSON array of raw bigram keys
+                    t.column("session_length", .text).notNull()   // "Short" / "Normal" / "Long"
+                    t.column("accuracy", .integer).notNull()
+                    t.column("wpm", .integer).notNull()
+                    t.column("duration_seconds", .double).notNull()
+                    t.column("total_typed", .integer).notNull()
+                    t.column("total_correct", .integer).notNull()
+                }
+                try db.create(index: "training_results_date_idx",
+                              on: "training_results", columns: ["completed_at"], ifNotExists: true)
+            }
             try migrator.migrate(db)
 
             dbQueue = db

--- a/Sources/KeyLens/KeyCountStore+Training.swift
+++ b/Sources/KeyLens/KeyCountStore+Training.swift
@@ -1,0 +1,102 @@
+import Foundation
+import GRDB
+import KeyLensCore
+
+// MARK: - Training result persistence (Issue #88)
+
+extension KeyCountStore {
+
+    /// Persists a completed training session result to SQLite.
+    ///
+    /// Runs the INSERT on `queue` (serial, background) and calls `completion`
+    /// on the main thread once the write is done, so callers can safely
+    /// trigger a UI reload immediately after.
+    ///
+    /// - Parameters:
+    ///   - targets:       Raw bigram keys that were practiced, e.g. ["t→h", "h→e"].
+    ///   - sessionLength: The session length label ("Short", "Normal", "Long").
+    ///   - accuracy:      Percentage of correct keystrokes (0–100).
+    ///   - wpm:           Words per minute during the session.
+    ///   - duration:      Elapsed seconds from first keystroke to session end.
+    ///   - totalTyped:    Total keystrokes typed.
+    ///   - totalCorrect:  Correct keystrokes typed.
+    ///   - completion:    Called on main thread after the write completes.
+    func saveTrainingResult(
+        targets: [String],
+        sessionLength: String,
+        accuracy: Int,
+        wpm: Int,
+        duration: Double,
+        totalTyped: Int,
+        totalCorrect: Int,
+        completion: @escaping () -> Void = {}
+    ) {
+        queue.async { [weak self] in
+            guard let self, let db = self.dbQueue else {
+                DispatchQueue.main.async { completion() }
+                return
+            }
+            let targetsJSON = (try? JSONSerialization.data(withJSONObject: targets))
+                .flatMap { String(data: $0, encoding: .utf8) } ?? "[]"
+            let now = Date().timeIntervalSince1970
+            try? db.write { db in
+                try db.execute(
+                    sql: """
+                        INSERT INTO training_results
+                            (completed_at, targets, session_length,
+                             accuracy, wpm, duration_seconds, total_typed, total_correct)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                    arguments: [now, targetsJSON, sessionLength,
+                                accuracy, wpm, duration, totalTyped, totalCorrect]
+                )
+            }
+            DispatchQueue.main.async { completion() }
+        }
+    }
+
+    /// Returns the most recent training results, newest first.
+    ///
+    /// - Parameter limit: Maximum number of records to return (default: 20).
+    func trainingHistory(limit: Int = 20) -> [TrainingRecord] {
+        queue.sync {
+            guard let db = dbQueue else { return [] }
+            let rows = (try? db.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT id, completed_at, targets, session_length,
+                           accuracy, wpm, duration_seconds, total_typed, total_correct
+                    FROM training_results
+                    ORDER BY completed_at DESC
+                    LIMIT ?
+                    """, arguments: [limit])
+            }) ?? []
+
+            return rows.compactMap { row -> TrainingRecord? in
+                let id: Int64           = row["id"]
+                let completedAt: Double = row["completed_at"]
+                let targetsJSON: String = row["targets"]
+                let sessionLength: String = row["session_length"]
+                let accuracy: Int       = row["accuracy"]
+                let wpm: Int            = row["wpm"]
+                let duration: Double    = row["duration_seconds"]
+                let totalTyped: Int     = row["total_typed"]
+                let totalCorrect: Int   = row["total_correct"]
+
+                let targets = (try? JSONSerialization.jsonObject(with: Data(targetsJSON.utf8)))
+                    .flatMap { $0 as? [String] } ?? []
+
+                return TrainingRecord(
+                    id: id,
+                    completedAt: Date(timeIntervalSince1970: completedAt),
+                    targets: targets,
+                    sessionLength: sessionLength,
+                    accuracy: accuracy,
+                    wpm: wpm,
+                    durationSeconds: duration,
+                    totalTyped: totalTyped,
+                    totalCorrect: totalCorrect
+                )
+            }
+        }
+    }
+}

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1252,6 +1252,18 @@ final class L10n {
 
     var trainingRegenerateButton: String { ja("セッションを更新", en: "New Session") }
 
+    var trainingHistoryTitle: String { ja("トレーニング履歴", en: "Training History") }
+    var helpTrainingHistory: String {
+        ja("過去のトレーニングセッションの結果を新しい順に表示します。",
+           en: "Past training session results, newest first.")
+    }
+    var trainingHistoryEmpty: String {
+        ja("まだ完了したセッションがありません。", en: "No completed sessions yet.")
+    }
+    var trainingHistoryDate: String    { ja("日時", en: "Date") }
+    var trainingHistoryTargets: String { ja("対象", en: "Targets") }
+    var trainingHistoryLength: String  { ja("長さ", en: "Length") }
+
     // MARK: - Chart Axis Labels
 
     var axisLabelKeys: String     { ja("キー数", en: "Keys") }

--- a/Sources/KeyLensCore/TrainingRecord.swift
+++ b/Sources/KeyLensCore/TrainingRecord.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// A single completed training session persisted to SQLite.
+///
+/// Stores enough data to evaluate whether training is helping over time:
+/// which bigrams were targeted, how accurately they were typed, how fast,
+/// and how long the session lasted.
+public struct TrainingRecord: Identifiable, Equatable {
+    public let id: Int64
+    /// When the session was completed.
+    public let completedAt: Date
+    /// Raw bigram keys that were targeted, e.g. ["t→h", "h→e"].
+    public let targets: [String]
+    /// Session length label: "Short", "Normal", or "Long".
+    public let sessionLength: String
+    /// Accuracy as a percentage (0–100).
+    public let accuracy: Int
+    /// Words per minute achieved during the session.
+    public let wpm: Int
+    /// Total elapsed time in seconds (first keystroke → last drill complete).
+    public let durationSeconds: Double
+    /// Total keystrokes typed (including incorrect ones).
+    public let totalTyped: Int
+    /// Correctly typed keystrokes.
+    public let totalCorrect: Int
+
+    public init(
+        id: Int64,
+        completedAt: Date,
+        targets: [String],
+        sessionLength: String,
+        accuracy: Int,
+        wpm: Int,
+        durationSeconds: Double,
+        totalTyped: Int,
+        totalCorrect: Int
+    ) {
+        self.id              = id
+        self.completedAt     = completedAt
+        self.targets         = targets
+        self.sessionLength   = sessionLength
+        self.accuracy        = accuracy
+        self.wpm             = wpm
+        self.durationSeconds = durationSeconds
+        self.totalTyped      = totalTyped
+        self.totalCorrect    = totalCorrect
+    }
+
+    /// Bigram keys converted to display strings, e.g. "t→h" → "th".
+    public var targetDisplayStrings: [String] {
+        targets.map { key in
+            let parts = key.components(separatedBy: "→")
+            guard parts.count == 2 else { return key }
+            return parts[0] + parts[1]
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a `training_results` SQLite table (via GRDB `v3` migration in `keylens.db`)
- Each completed session saves: timestamp, target bigrams, session length, accuracy %, WPM, duration, total/correct keystrokes
- New **Training History** section in the Training tab shows last 20 sessions: date, targets, length, accuracy (color-coded), WPM, time
- History auto-refreshes after each session via `saveTrainingResult(completion:)` → `model.reload()`

## New files

- `KeyLensCore/TrainingRecord.swift` — plain data model
- `KeyLens/KeyCountStore+Training.swift` — `saveTrainingResult()` + `trainingHistory()` using GRDB

## Test plan

- [ ] Complete a training session → Training History section shows the result
- [ ] Accuracy color coding: green ≥90%, orange ≥70%, red <70%
- [ ] Complete multiple sessions → all appear, newest first
- [ ] Restart the app → history persists across launches
- [ ] History section shows empty state when no sessions completed yet