### PR TITLE
feat: add 2D heatmap (Day of Week × Hour of Day) to Activity tab (Close #78)

### DIFF
--- a/Sources/KeyLens/Charts+ActivityTab.swift
+++ b/Sources/KeyLens/Charts+ActivityTab.swift
@@ -10,6 +10,7 @@ extension ChartsView {
                 chartSection(L10n.shared.chartTitleTypingSpeed, helpText: L10n.shared.helpTypingSpeed) { dailyWPMChart }
                 chartSection(L10n.shared.chartTitleBackspaceRate, helpText: L10n.shared.helpBackspaceRate) { dailyAccuracyChart }
                 chartSection(L10n.shared.chartTitleIKIHistogram, helpText: L10n.shared.helpIKIHistogram) { ikiHistogramChart }
+                chartSection(L10n.shared.chartTitleWeeklyHeatmap, helpText: L10n.shared.helpWeeklyHeatmap) { weeklyHeatmapChart }
                 chartSection("Hourly Distribution", helpText: L10n.shared.helpHourlyDistribution) { hourlyDistributionChart }
                 chartSection("Daily Totals", helpText: L10n.shared.helpDailyTotals) { dailyTotalsChart }
                 chartSection("Monthly Totals", helpText: L10n.shared.helpMonthlyTotals) { monthlyTotalsChart }
@@ -182,6 +183,20 @@ extension ChartsView {
             }
             .chartYAxisLabel(L10n.shared.axisLabelPercent, alignment: .trailing)
             .frame(height: 200)
+        }
+    }
+
+    // MARK: - Issue #78: Weekly Activity Heatmap
+
+    /// 7×24 grid heatmap: average keystrokes per (day-of-week, hour) cell.
+    /// 曜日×時刻の週間ヒートマップ (Issue #78)。
+    @ViewBuilder
+    var weeklyHeatmapChart: some View {
+        let cells = model.weeklyHeatmap
+        if cells.isEmpty || cells.allSatisfy({ $0.avgCount == 0 }) {
+            emptyState
+        } else {
+            WeeklyHeatmapView(cells: cells)
         }
     }
 
@@ -378,6 +393,104 @@ extension ChartsView {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+    }
+}
+
+// MARK: - Issue #78: WeeklyHeatmapView
+
+/// A 7-column × 24-row grid showing average keystrokes per (day-of-week, hour) cell.
+/// Color intensity scales linearly from the cell's avgCount to the maximum across all cells.
+/// Hovering over a cell shows a tooltip below the grid.
+struct WeeklyHeatmapView: View {
+    let cells: [HeatmapCell]
+
+    @State private var hoveredCell: HeatmapCell? = nil
+
+    private let cellW:   CGFloat = 26
+    private let cellH:   CGFloat = 10
+    private let labelW:  CGFloat = 28
+    private let headerH: CGFloat = 22
+
+    // Pre-build lookup [weekday * 24 + hour → cell] for O(1) access.
+    private var lookup: [Int: HeatmapCell] {
+        Dictionary(uniqueKeysWithValues: cells.map { ($0.weekday * 24 + $0.hour, $0) })
+    }
+
+    private var maxAvg: Double {
+        cells.map(\.avgCount).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            grid
+            tooltipLine
+        }
+    }
+
+    private var grid: some View {
+        HStack(alignment: .top, spacing: 0) {
+            hourLabels
+            ForEach(0..<7, id: \.self) { wd in
+                dayColumn(wd: wd)
+            }
+        }
+    }
+
+    private var hourLabels: some View {
+        VStack(spacing: 0) {
+            Spacer().frame(height: headerH)
+            ForEach(0..<24, id: \.self) { h in
+                Text(h % 3 == 0 ? String(format: "%02d", h) : "")
+                    .font(.system(size: 8))
+                    .foregroundStyle(.secondary)
+                    .frame(width: labelW, height: cellH, alignment: .trailing)
+                    .padding(.trailing, 3)
+            }
+        }
+    }
+
+    private func dayColumn(wd: Int) -> some View {
+        let abbrs = L10n.shared.weekdayAbbrs
+        let label = wd < abbrs.count ? abbrs[wd] : ""
+        return VStack(spacing: 0) {
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: cellW, height: headerH)
+            ForEach(0..<24, id: \.self) { h in
+                cellView(wd: wd, hour: h)
+            }
+        }
+    }
+
+    private func cellView(wd: Int, hour: Int) -> some View {
+        let cell = lookup[wd * 24 + hour]
+        let avg  = cell?.avgCount ?? 0
+        let intensity = maxAvg > 0 ? avg / maxAvg : 0
+        // Minimum opacity 0.06 so empty cells remain visible as outlines.
+        let fill = Color.blue.opacity(0.06 + intensity * 0.88)
+        return Rectangle()
+            .fill(fill)
+            .frame(width: cellW - 1, height: cellH - 1)
+            .cornerRadius(1)
+            .onHover { hovering in
+                hoveredCell = hovering ? cell : nil
+            }
+    }
+
+    @ViewBuilder
+    private var tooltipLine: some View {
+        if let cell = hoveredCell {
+            let fullNames = L10n.shared.weekdayFullNames
+            let dayName   = cell.weekday < fullNames.count ? fullNames[cell.weekday] : ""
+            let hourStr   = String(format: "%02d:00", cell.hour)
+            let avgLabel  = L10n.shared.heatmapAvgLabel(Int(cell.avgCount.rounded()))
+            Text("\(dayName) \(hourStr)  ·  \(avgLabel)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            Text(" ").font(.caption)  // fixed-height placeholder keeps layout stable
         }
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -273,6 +273,23 @@ struct MouseKeyboardBalanceEntry: Identifiable {
     let keystrokes: Int
 }
 
+// MARK: - Issue #78: Weekly Activity Heatmap
+
+/// One cell in the 7×24 weekly heatmap: average keystrokes for a given (weekday, hour) pair.
+/// 週間ヒートマップの1セル：曜日×時刻ごとの平均打鍵数。
+struct HeatmapCell: Identifiable {
+    let id: Int           // weekday * 24 + hour
+    let weekday: Int      // 0 = Sunday … 6 = Saturday
+    let hour: Int         // 0–23
+    let avgCount: Double  // average keystrokes across all matching dates
+    init(_ t: (weekday: Int, hour: Int, avgCount: Double)) {
+        id = t.weekday * 24 + t.hour
+        weekday  = t.weekday
+        hour     = t.hour
+        avgCount = t.avgCount
+    }
+}
+
 // MARK: - Issue #63: Hourly fatigue entry
 
 /// One data point in the Fatigue Curve chart: per-hour WPM and ergonomic rates for today.

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -77,6 +77,8 @@ final class ChartDataModel: ObservableObject {
     @Published var trainingHistory:            [TrainingRecord]              = []
     // Issue #84: Full bigram → current mean IKI map for before/after comparison in training history.
     @Published var bigramIKIMap:               [String: Double]              = [:]
+    // Issue #78: Weekly Activity Heatmap
+    @Published var weeklyHeatmap:              [HeatmapCell]                 = []
 
     func reload() {
         let store            = KeyCountStore.shared
@@ -125,6 +127,8 @@ final class ChartDataModel: ObservableObject {
         // Issue #5: Activity Trends
         hourlyDistribution = store.hourlyDistribution()
         monthlyTotals      = store.monthlyTotals().map(MonthlyTotalEntry.init)
+        // Issue #78: Weekly Activity Heatmap
+        weeklyHeatmap = store.hourlyCountsByDayOfWeek().map(HeatmapCell.init)
         // Per-application counts
         topApps      = store.topApps(limit: 20).map(AppEntry.init)
         todayTopApps = store.todayTopApps(limit: 10).map(AppEntry.init)

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -522,6 +522,63 @@ extension KeyCountStore {
         }
     }
 
+    /// Average keystroke count per (weekday, hour) cell across all recorded dates.
+    /// weekday: 0 = Sunday … 6 = Saturday  |  hour: 0–23
+    /// Used by the Weekly Activity Heatmap (Issue #78).
+    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double)] {
+        queue.sync {
+            // sums[weekday][hour] = cumulative keystroke count
+            // days[weekday]       = set of distinct dates seen for that weekday
+            var sums = [Int: [Int: Int]]()
+            var days = [Int: Set<String>]()
+
+            if let db = dbQueue,
+               let rows = try? db.read({ db in
+                   try Row.fetchAll(db, sql: """
+                       SELECT date,
+                              CAST(strftime('%w', date) AS INTEGER) AS weekday,
+                              hour,
+                              count
+                       FROM hourly_counts
+                       """)
+               }) {
+                for row in rows {
+                    let date: String = row["date"]
+                    let wd: Int      = row["weekday"]
+                    let h: Int       = row["hour"]
+                    let c: Int       = row["count"]
+                    guard h < 24 else { continue }
+                    sums[wd, default: [:]][h, default: 0] += c
+                    days[wd, default: []].insert(date)
+                }
+            }
+
+            // Merge pending in-memory data.
+            let cal = Calendar.current
+            for (date, hours) in pending.hourly {
+                guard let d = Self.dayFormatter.date(from: date) else { continue }
+                // Calendar.weekday: 1 = Sunday … 7 = Saturday  →  convert to 0-based
+                let wd = cal.component(.weekday, from: d) - 1
+                days[wd, default: []].insert(date)
+                for (h, v) in hours where h < 24 {
+                    sums[wd, default: [:]][h, default: 0] += v
+                }
+            }
+
+            // Build result ordered by weekday then hour.
+            var result: [(weekday: Int, hour: Int, avgCount: Double)] = []
+            for wd in 0..<7 {
+                let dayCount = days[wd]?.count ?? 0
+                for h in 0..<24 {
+                    let sum = sums[wd]?[h] ?? 0
+                    let avg = dayCount > 0 ? Double(sum) / Double(dayCount) : 0.0
+                    result.append((weekday: wd, hour: h, avgCount: avg))
+                }
+            }
+            return result
+        }
+    }
+
     /// Aggregate hourly keystroke counts across all recorded dates.
     func hourlyDistribution() -> [Int] {
         queue.sync {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1365,6 +1365,40 @@ final class L10n {
            en: "Total click counts for left, middle, and right mouse buttons.")
     }
 
+    // MARK: - Issue #78: Weekly Activity Heatmap
+
+    var chartTitleWeeklyHeatmap: String {
+        ja("週間活動ヒートマップ", en: "Weekly Activity Heatmap")
+    }
+
+    var helpWeeklyHeatmap: String {
+        ja(
+            "曜日 (列) と時刻 (行) ごとの平均打鍵数を色の濃さで表します。濃いほど入力量が多い時間帯です。全記録期間の平均値を表示します。",
+            en: "Average keystrokes per hour for each day of the week, across all recorded dates. Darker cells indicate more typing activity."
+        )
+    }
+
+    /// Weekday abbreviations ordered Sunday–Saturday (index 0–6).
+    /// 曜日略称、日〜土 (添字 0–6)。
+    var weekdayAbbrs: [String] {
+        resolved == .japanese
+            ? ["日", "月", "火", "水", "木", "金", "土"]
+            : ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+    }
+
+    /// Full weekday names ordered Sunday–Saturday (index 0–6).
+    /// 曜日フル名称、日〜土 (添字 0–6)。
+    var weekdayFullNames: [String] {
+        resolved == .japanese
+            ? ["日曜", "月曜", "火曜", "水曜", "木曜", "金曜", "土曜"]
+            : ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    }
+
+    /// Tooltip label for heatmap cell: "avg N keys" / "平均 N キー".
+    func heatmapAvgLabel(_ count: Int) -> String {
+        ja("平均 \(count) キー", en: "avg \(count) keys")
+    }
+
     // MARK: - Issue #60: Session detection
 
     var chartTitleSessions: String {


### PR DESCRIPTION
## Summary
- Adds a 2D heatmap grid (Day of Week × Hour of Day) to the Activity tab in Charts
- New `hourlyByDayOfWeek()` query in `KeyCountStore+Activity.swift` aggregates keystroke data by day/hour
- New `HeatmapEntry` data type in `ChartsDataTypes.swift`
- All strings bilingual (EN/JA) via `L10n.swift`

## Test plan
- [ ] Open Charts → Activity tab and verify heatmap renders
- [ ] Check that peak hours/days are highlighted correctly

Closes #78