### PR TITLE
feat: Period Comparison tab (Issue #62)

### DIFF
--- a/Sources/KeyLens/Charts+ComparisonTab.swift
+++ b/Sources/KeyLens/Charts+ComparisonTab.swift
@@ -1,0 +1,249 @@
+import SwiftUI
+import Charts
+import KeyLensCore
+
+// MARK: - Period Comparison Tab (Issue #62)
+
+extension ChartsView {
+
+    var comparisonTab: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 40) {
+                chartSection(
+                    L10n.shared.chartTitlePeriodComparison,
+                    helpText: L10n.shared.helpPeriodComparison
+                ) {
+                    comparisonControls
+                }
+
+                chartSection(L10n.shared.chartTitlePeriodComparison) {
+                    comparisonChart
+                }
+
+                chartSection(L10n.shared.chartTitlePeriodComparison) {
+                    comparisonSummaryTable
+                }
+            }
+            .padding(24)
+        }
+        .onChange(of: comparisonPreset) { _ in applyPreset() }
+    }
+
+    // MARK: - Controls (preset picker + custom date pickers)
+
+    @ViewBuilder
+    var comparisonControls: some View {
+        let l = L10n.shared
+        VStack(alignment: .leading, spacing: 16) {
+            // Preset buttons
+            HStack(spacing: 8) {
+                presetButton(label: l.comparisonPresetWeek,  tag: 1)
+                presetButton(label: l.comparisonPresetMonth, tag: 2)
+                presetButton(label: l.comparisonPresetCustom, tag: 0)
+            }
+
+            // Date pickers (always visible; disabled when a preset is active)
+            Grid(alignment: .leading, horizontalSpacing: 16, verticalSpacing: 8) {
+                GridRow {
+                    Text(l.comparisonPeriodA)
+                        .font(.subheadline.bold())
+                        .foregroundStyle(theme.accentColor)
+                        .gridColumnAlignment(.leading)
+                    DatePicker(l.comparisonFrom, selection: $comparisonAStart,
+                               in: ...comparisonAEnd, displayedComponents: .date)
+                        .labelsHidden()
+                        .disabled(comparisonPreset != 0)
+                    DatePicker(l.comparisonTo,   selection: $comparisonAEnd,
+                               in: comparisonAStart..., displayedComponents: .date)
+                        .labelsHidden()
+                        .disabled(comparisonPreset != 0)
+                }
+                GridRow {
+                    Text(l.comparisonPeriodB)
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.orange)
+                        .gridColumnAlignment(.leading)
+                    DatePicker(l.comparisonFrom, selection: $comparisonBStart,
+                               in: ...comparisonBEnd, displayedComponents: .date)
+                        .labelsHidden()
+                        .disabled(comparisonPreset != 0)
+                    DatePicker(l.comparisonTo,   selection: $comparisonBEnd,
+                               in: comparisonBStart..., displayedComponents: .date)
+                        .labelsHidden()
+                        .disabled(comparisonPreset != 0)
+                }
+            }
+            .opacity(comparisonPreset == 0 ? 1.0 : 0.6)
+        }
+    }
+
+    @ViewBuilder
+    func presetButton(label: String, tag: Int) -> some View {
+        Button(label) { comparisonPreset = tag }
+            .buttonStyle(.bordered)
+            .tint(comparisonPreset == tag ? theme.accentColor : .secondary)
+    }
+
+    // MARK: - Overlaid chart
+
+    @ViewBuilder
+    var comparisonChart: some View {
+        let seriesA = comparisonSeries(from: comparisonAStart, to: comparisonAEnd, label: L10n.shared.comparisonPeriodA)
+        let seriesB = comparisonSeries(from: comparisonBStart, to: comparisonBEnd, label: L10n.shared.comparisonPeriodB)
+        let allEmpty = seriesA.isEmpty && seriesB.isEmpty
+
+        if allEmpty {
+            Text(L10n.shared.comparisonNoData)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, minHeight: 60, alignment: .center)
+        } else {
+            let combined = seriesA + seriesB
+            Chart(combined) { point in
+                AreaMark(
+                    x: .value(L10n.shared.comparisonDayOffset, point.dayOffset),
+                    y: .value(L10n.shared.axisLabelKeys, point.total)
+                )
+                .foregroundStyle(by: .value("Period", point.series))
+                .opacity(0.12)
+                LineMark(
+                    x: .value(L10n.shared.comparisonDayOffset, point.dayOffset),
+                    y: .value(L10n.shared.axisLabelKeys, point.total)
+                )
+                .foregroundStyle(by: .value("Period", point.series))
+                .interpolationMethod(.catmullRom)
+                PointMark(
+                    x: .value(L10n.shared.comparisonDayOffset, point.dayOffset),
+                    y: .value(L10n.shared.axisLabelKeys, point.total)
+                )
+                .foregroundStyle(by: .value("Period", point.series))
+                .symbolSize(25)
+            }
+            .chartForegroundStyleScale([
+                L10n.shared.comparisonPeriodA: theme.accentColor,
+                L10n.shared.comparisonPeriodB: Color.orange,
+            ])
+            .chartXAxisLabel(L10n.shared.comparisonDayOffset)
+            .chartYAxisLabel(L10n.shared.axisLabelKeys, alignment: .trailing)
+            .frame(height: 220)
+        }
+    }
+
+    // MARK: - Summary table
+
+    @ViewBuilder
+    var comparisonSummaryTable: some View {
+        let l = L10n.shared
+        let statsA = comparisonStats(from: comparisonAStart, to: comparisonAEnd)
+        let statsB = comparisonStats(from: comparisonBStart, to: comparisonBEnd)
+
+        Grid(alignment: .trailing, horizontalSpacing: 20, verticalSpacing: 0) {
+            GridRow {
+                Text("").gridColumnAlignment(.leading)
+                Text(l.comparisonPeriodA)
+                    .font(.caption).bold()
+                    .foregroundStyle(theme.accentColor)
+                Text(l.comparisonPeriodB)
+                    .font(.caption).bold()
+                    .foregroundStyle(.orange)
+                Text("Δ").font(.caption).bold().foregroundStyle(.secondary)
+            }
+            .padding(.bottom, 6)
+            Divider().gridCellUnsizedAxes(.horizontal)
+
+            summaryRow(label: l.comparisonTotalKeys,
+                       a: statsA.total, b: statsB.total,
+                       format: { Int($0).formatted() }, lowerIsBetter: false)
+            summaryRow(label: l.comparisonAvgPerDay,
+                       a: statsA.avgPerDay, b: statsB.avgPerDay,
+                       format: { Int($0).formatted() }, lowerIsBetter: false)
+            summaryRow(label: l.comparisonPeakDay,
+                       a: statsA.peak, b: statsB.peak,
+                       format: { Int($0).formatted() }, lowerIsBetter: false)
+        }
+    }
+
+    @ViewBuilder
+    func summaryRow(label: String, a: Double, b: Double,
+                    format: (Double) -> String, lowerIsBetter: Bool) -> some View {
+        let delta = a - b
+        let threshold = max(a, b) * 0.01
+        let isImprovement = lowerIsBetter ? delta < -threshold : delta > threshold
+        let isRegression  = lowerIsBetter ? delta > threshold  : delta < -threshold
+        let deltaColor: Color = isImprovement ? .green : (isRegression ? .red : .secondary)
+        let arrow = delta > threshold ? "↑" : (delta < -threshold ? "↓" : "→")
+
+        GridRow {
+            Text(label)
+                .font(.callout)
+                .gridColumnAlignment(.leading)
+            Text(format(a))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(theme.accentColor)
+            Text(format(b))
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(.orange)
+            Text("\(arrow) \(format(abs(delta)))")
+                .font(.callout.monospacedDigit())
+                .foregroundStyle(deltaColor)
+        }
+        .padding(.vertical, 5)
+    }
+
+    // MARK: - Data helpers
+
+    /// Build an array of (dayOffset, total, series) for chart plotting.
+    private func comparisonSeries(from start: Date, to end: Date, label: String) -> [ComparisonPoint] {
+        KeyCountStore.shared.dailyTotals(from: start, to: end)
+            .enumerated()
+            .map { i, item in ComparisonPoint(dayOffset: i + 1, total: item.total, series: label) }
+    }
+
+    private struct ComparisonStats {
+        var total: Double
+        var avgPerDay: Double
+        var peak: Double
+    }
+
+    private func comparisonStats(from start: Date, to end: Date) -> ComparisonStats {
+        let data = KeyCountStore.shared.dailyTotals(from: start, to: end)
+        let total = Double(data.map(\.total).reduce(0, +))
+        let days  = Double(max(data.count, 1))
+        let peak  = Double(data.map(\.total).max() ?? 0)
+        return ComparisonStats(total: total, avgPerDay: total / days, peak: peak)
+    }
+
+    // MARK: - Preset application
+
+    private func applyPreset() {
+        let cal = Calendar.current
+        let today = Date()
+        switch comparisonPreset {
+        case 1: // This week (Mon–today) vs last week
+            let weekday = cal.component(.weekday, from: today)
+            let daysFromMonday = (weekday + 5) % 7  // 0 = Mon, 6 = Sun
+            comparisonAStart = cal.date(byAdding: .day, value: -daysFromMonday, to: today) ?? today
+            comparisonAEnd   = today
+            comparisonBStart = cal.date(byAdding: .day, value: -(daysFromMonday + 7), to: today) ?? today
+            comparisonBEnd   = cal.date(byAdding: .day, value: -(daysFromMonday + 1), to: today) ?? today
+        case 2: // This month vs last month
+            let startOfThisMonth = cal.date(from: cal.dateComponents([.year, .month], from: today)) ?? today
+            let startOfLastMonth = cal.date(byAdding: .month, value: -1, to: startOfThisMonth) ?? today
+            let endOfLastMonth   = cal.date(byAdding: .day, value: -1, to: startOfThisMonth) ?? today
+            comparisonAStart = startOfThisMonth
+            comparisonAEnd   = today
+            comparisonBStart = startOfLastMonth
+            comparisonBEnd   = endOfLastMonth
+        default:
+            break  // custom — leave pickers as-is
+        }
+    }
+}
+
+// MARK: - Chart data point
+
+private struct ComparisonPoint: Identifiable {
+    let id = UUID()
+    let dayOffset: Int
+    let total: Int
+    let series: String
+}

--- a/Sources/KeyLens/ChartsComponents.swift
+++ b/Sources/KeyLens/ChartsComponents.swift
@@ -39,6 +39,7 @@ enum ChartTab: String, CaseIterable, Identifiable {
     case apps        = "Apps"
     case mouse       = "Mouse"
     case training    = "Training"
+    case comparison  = "Compare"
 
     var id: String { rawValue }
 
@@ -53,6 +54,7 @@ enum ChartTab: String, CaseIterable, Identifiable {
         case .apps:       return "app.badge"
         case .mouse:      return "cursorarrow.motionlines"
         case .training:   return "figure.run"
+        case .comparison: return "arrow.left.arrow.right"
         }
     }
 }

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -40,6 +40,14 @@ struct ChartsView: View {
     /// Controls the confirmation alert for clearing training history.
     @State var showClearHistoryAlert = false
 
+    // MARK: - Issue #62: Period Comparison state
+    /// Which preset is selected (0 = custom, 1 = this week vs last, 2 = this month vs last month)
+    @State var comparisonPreset: Int = 1
+    @State var comparisonAStart: Date = Calendar.current.date(byAdding: .day, value: -6, to: Date()) ?? Date()
+    @State var comparisonAEnd: Date   = Date()
+    @State var comparisonBStart: Date = Calendar.current.date(byAdding: .day, value: -13, to: Date()) ?? Date()
+    @State var comparisonBEnd: Date   = Calendar.current.date(byAdding: .day, value: -7, to: Date()) ?? Date()
+
     /// Fixed width keeps the live IKI snapshot compact when copying to the clipboard.
     /// 最新20打鍵グラフのコピーサイズを安定させるための固定幅。
     let recentIKIChartWidth: CGFloat = 560
@@ -92,6 +100,10 @@ struct ChartsView: View {
             trainingTab
                 .tabItem { Label(ChartTab.training.rawValue, systemImage: ChartTab.training.icon) }
                 .tag(ChartTab.training)
+
+            comparisonTab
+                .tabItem { Label(ChartTab.comparison.rawValue, systemImage: ChartTab.comparison.icon) }
+                .tag(ChartTab.comparison)
         }
         .padding(.top, 8)
         .frame(minWidth: 680, minHeight: 480)

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -481,6 +481,41 @@ extension KeyCountStore {
         }
     }
 
+    /// Per-day keystroke totals between two dates (inclusive), oldest first.
+    /// Days with no data are included with a count of 0.
+    func dailyTotals(from startDate: Date, to endDate: Date) -> [(date: String, total: Int)] {
+        let cal = Calendar.current
+        let start = min(startDate, endDate)
+        let end   = max(startDate, endDate)
+        return queue.sync {
+            guard let db = dbQueue else { return [] }
+            let startKey = Self.dayFormatter.string(from: start)
+            let endKey   = Self.dayFormatter.string(from: end)
+            var map: [String: Int] = [:]
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date, SUM(count) as total FROM daily_keys
+                    WHERE date >= ? AND date <= ? GROUP BY date
+                    """, arguments: [startKey, endKey])
+            }) {
+                for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
+            }
+            for (date, keys) in pending.dailyKeys where date >= startKey && date <= endKey {
+                map[date, default: 0] += keys.values.reduce(0, +)
+            }
+            // Enumerate every calendar day in the range, filling zeros for missing days
+            var result: [(date: String, total: Int)] = []
+            var cursor = start
+            while cursor <= end {
+                let key = Self.dayFormatter.string(from: cursor)
+                result.append((date: key, total: map[key] ?? 0))
+                guard let next = cal.date(byAdding: .day, value: 1, to: cursor) else { break }
+                cursor = next
+            }
+            return result
+        }
+    }
+
     /// All daily totals sorted ascending by date.
     func dailyTotals() -> [(date: String, total: Int)] {
         queue.sync {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1508,6 +1508,29 @@ final class L10n {
         }
     }
 
+    // MARK: - Period Comparison (Issue #62)
+
+    var chartTitlePeriodComparison: String { ja("期間比較", en: "Period Comparison") }
+    var comparisonPeriodA: String          { ja("期間 A", en: "Period A") }
+    var comparisonPeriodB: String          { ja("期間 B", en: "Period B") }
+    var comparisonFrom: String             { ja("開始", en: "From") }
+    var comparisonTo: String               { ja("終了", en: "To") }
+    var comparisonPresetCustom: String     { ja("カスタム", en: "Custom") }
+    var comparisonPresetWeek: String       { ja("今週 vs 先週", en: "This Week vs Last Week") }
+    var comparisonPresetMonth: String      { ja("今月 vs 先月", en: "This Month vs Last Month") }
+    var comparisonTotalKeys: String        { ja("合計打鍵数", en: "Total Keystrokes") }
+    var comparisonAvgPerDay: String        { ja("1日平均", en: "Avg / Day") }
+    var comparisonPeakDay: String          { ja("ピーク日", en: "Peak Day") }
+    var comparisonNoData: String           { ja("選択期間にデータがありません", en: "No data for the selected period") }
+    var comparisonDayOffset: String        { ja("日目", en: "Day") }
+
+    var helpPeriodComparison: String {
+        ja(
+            "任意の2期間を選んで打鍵数を重ね合わせて比較します。プリセットで今週/今月と前の期間を素早く選択できます。\n\nX軸は期間の開始からの経過日数を示します。",
+            en: "Compare keystroke totals across any two date ranges, overlaid on a single chart. Use the presets to quickly compare this week or month against the previous period.\n\nThe X-axis shows days elapsed from the start of each period."
+        )
+    }
+
     // MARK: - Helper
 
     private func ja(_ japanese: String, en english: String) -> String {


### PR DESCRIPTION
## Summary

- Adds a **Compare** tab to the Charts window for side-by-side period comparison
- Users can pick **This Week vs Last Week**, **This Month vs Last Month**, or set fully **custom** date ranges via date pickers
- Overlaid area+line chart plots both periods on the same x-axis (day offset from range start)
- Summary table shows Total Keystrokes, Avg/Day, and Peak Day for each period with a Δ column
- All strings are bilingual (English + Japanese) via `L10n.swift`

## Files changed

| File | Change |
|---|---|
| `KeyCountStore+Activity.swift` | New `dailyTotals(from:to:)` query method |
| `ChartsComponents.swift` | Added `.comparison` case to `ChartTab` enum |
| `L10n.swift` | 14 new bilingual strings under `// MARK: - Period Comparison` |
| `ChartsView.swift` | 5 new `@State` properties + `comparisonTab` wired into `TabView` |
| `Charts+ComparisonTab.swift` | **New file** — full tab implementation |

## Build

`swift build -c release` — Build complete

Closes #62