### PR TITLE
refactor: extract KeyMetricsComputation (#215)

### DIFF
--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -80,7 +80,7 @@ extension KeyCountStore {
                 .compactMap { (app, keystrokes) -> (app: String, score: Double, keystrokes: Int)? in
                     let bigrams = store.appTracker.appTotalBigramCount[app] ?? 0
                     guard bigrams > 0 else { return nil }
-                    let score = ergonomicScore(
+                    let score = KeyMetricsComputation.ergonomicScore(
                         sfCount:     store.appTracker.appSameFingerCount[app]       ?? 0,
                         hsCount:     store.appTracker.appHighStrainBigramCount[app] ?? 0,
                         altCount:    store.appTracker.appHandAlternationCount[app]  ?? 0,
@@ -100,7 +100,7 @@ extension KeyCountStore {
                 .compactMap { (device, keystrokes) -> (device: String, score: Double, keystrokes: Int)? in
                     let bigrams = store.appTracker.deviceTotalBigramCount[device] ?? 0
                     guard bigrams > 0 else { return nil }
-                    let score = ergonomicScore(
+                    let score = KeyMetricsComputation.ergonomicScore(
                         sfCount:     store.appTracker.deviceSameFingerCount[device]       ?? 0,
                         hsCount:     store.appTracker.deviceHighStrainBigramCount[device] ?? 0,
                         altCount:    store.appTracker.deviceHandAlternationCount[device]  ?? 0,

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -226,7 +226,7 @@ extension KeyCountStore {
     /// Unified ergonomic score (0–100) from cumulative keystroke data (Issue #29).
     var currentErgonomicScore: Double {
         queue.sync {
-            ergonomicScore(
+            KeyMetricsComputation.ergonomicScore(
                 sfCount:      store.ergonomics.sameFingerCount,
                 hsCount:      store.ergonomics.highStrainBigramCount,
                 altCount:     store.ergonomics.handAlternationCount,
@@ -310,7 +310,7 @@ extension KeyCountStore {
             for date in allDatesLocked() {
                 let bigrams = store.ergonomics.dailyTotalBigramCount[date] ?? 0
                 guard bigrams > 0 else { continue }
-                result[date] = ergonomicScore(
+                result[date] = KeyMetricsComputation.ergonomicScore(
                     sfCount:     store.ergonomics.dailySameFingerCount[date]       ?? 0,
                     hsCount:     store.ergonomics.dailyHighStrainBigramCount[date] ?? 0,
                     altCount:    store.ergonomics.dailyHandAlternationCount[date]  ?? 0,
@@ -389,25 +389,3 @@ extension KeyCountStore {
     }
 }
 
-// MARK: - Private helpers
-
-extension KeyCountStore {
-
-    /// Computes a unified ergonomic score (0–100) from raw bigram counters.
-    /// Must be called from inside `queue.sync`.
-    func ergonomicScore(
-        sfCount:     Int,
-        hsCount:     Int,
-        altCount:    Int,
-        bigramCount: Int,
-        keyCounts:   [String: Int]? = nil
-    ) -> Double {
-        KeyMetricsComputation.ergonomicScore(
-            sfCount:     sfCount,
-            hsCount:     hsCount,
-            altCount:    altCount,
-            bigramCount: bigramCount,
-            keyCounts:   keyCounts
-        )
-    }
-}


### PR DESCRIPTION
## Summary

- Extracts `wpm()` and `ergonomicScore()` pure functions into a new `KeyMetricsComputation` enum
- Removes the private `ergonomicScore(...)` wrapper from `KeyCountStore+Ergonomics.swift`
- All 4 call sites now call `KeyMetricsComputation.ergonomicScore(...)` directly

## Files changed
- `Sources/KeyLens/KeyMetricsComputation.swift` — new file, pure computation helpers
- `Sources/KeyLens/KeyCountStore+Ergonomics.swift` — removed redundant wrapper, updated 2 call sites
- `Sources/KeyLens/KeyCountStore+Activity.swift` — updated 2 call sites

No behavior change. Improves testability — pure functions can be unit-tested without `KeyCountStore`.

Part of #215.