### PR TITLE
feat: adapt heatmap and activity calendar colors for dark mode

### DIFF
--- a/Sources/KeyLens/ActivityCalendarView.swift
+++ b/Sources/KeyLens/ActivityCalendarView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ActivityCalendarView: View {
     let dailyTotals: [DailyTotalEntry]
 
+    @Environment(\.colorScheme) private var colorScheme
+
     // Calendar cell size and spacing
     // カレンダーセルのサイズとスペーシング
     private let cellSize: CGFloat = 12
@@ -167,12 +169,13 @@ struct ActivityCalendarView: View {
     /// 正規化された割合 [0,1] を緑系の強度色にマッピングする。
     private func intensityColor(fraction: Double) -> Color {
         if fraction == 0 { return Color(NSColor.controlBackgroundColor).opacity(0.6) }
-        // 4-level green scale: light → dark
-        // 4段階の緑スケール：薄い → 濃い
+        // Dark mode uses higher opacity levels so faint cells remain visible on dark backgrounds.
+        // ダークモードでは暗い背景でも薄いセルが見えるよう、不透明度を高めに設定する。
+        let (l1, l2, l3): (Double, Double, Double) = colorScheme == .dark ? (0.40, 0.60, 0.80) : (0.25, 0.50, 0.75)
         switch fraction {
-        case 0..<0.25: return Color.green.opacity(0.25)
-        case 0.25..<0.50: return Color.green.opacity(0.50)
-        case 0.50..<0.75: return Color.green.opacity(0.75)
+        case 0..<0.25: return Color.green.opacity(l1)
+        case 0.25..<0.50: return Color.green.opacity(l2)
+        case 0.50..<0.75: return Color.green.opacity(l3)
         default:          return Color.green.opacity(1.00)
         }
     }

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -66,6 +66,14 @@ struct KeyboardHeatmapView: View {
     // Adapts to dark / light mode — dark: near-black, light: near-white
     private var emptyKeyColor: Color { colorScheme == .dark ? Color(white: 0.25) : Color(white: 0.85) }
 
+    // Returns a hue-based key fill color adjusted for the current color scheme.
+    // Dark mode raises brightness and lowers saturation so vivid keys don't overpower the dark UI.
+    private func heatColor(hue: Double) -> Color {
+        colorScheme == .dark
+            ? Color(hue: hue, saturation: 0.65, brightness: 0.92)
+            : Color(hue: hue, saturation: 0.75, brightness: 0.82)
+    }
+
     private let keyHeight: CGFloat = 40
     private let keySpacing: CGFloat = 4
 
@@ -523,6 +531,12 @@ struct HeatmapExportView: View {
 
     private var emptyKeyColor: Color { colorScheme == .dark ? Color(white: 0.25) : Color(white: 0.85) }
 
+    private func heatColor(hue: Double) -> Color {
+        colorScheme == .dark
+            ? Color(hue: hue, saturation: 0.65, brightness: 0.92)
+            : Color(hue: hue, saturation: 0.75, brightness: 0.82)
+    }
+
     private let keyHeight: CGFloat = 40
     private let keySpacing: CGFloat = 4
 
@@ -720,7 +734,7 @@ struct HeatmapExportView: View {
         let t = max > 0 && count > 0 ? Double(count) / Double(max) : 0
         let baseHue = ThemeStore.shared.current.heatmapBaseHue
         let hue = (1.0 - t) * baseHue
-        let bgColor = count > 0 ? Color(hue: hue, saturation: 0.75, brightness: 0.82) : emptyKeyColor
+        let bgColor = count > 0 ? heatColor(hue: hue) : emptyKeyColor
         let fgColor: Color = count > 0 ? .white : .secondary
 
         let accessibilityValue = tooltipOverride ?? tooltipText(for: count, style: tooltipStyle)
@@ -783,7 +797,7 @@ struct HeatmapExportView: View {
         let t = max > 0 && count > 0 ? Double(count) / Double(max) : 0
         let baseHue = ThemeStore.shared.current.heatmapBaseHue
         let hue = (1.0 - t) * baseHue
-        let bgColor = count > 0 ? Color(hue: hue, saturation: 0.75, brightness: 0.82) : emptyKeyColor
+        let bgColor = count > 0 ? heatColor(hue: hue) : emptyKeyColor
         let fgColor: Color = count > 0 ? .white : .secondary
 
         func s(_ i: Int) -> String { i < slots.count ? slots[i] : "" }
@@ -859,11 +873,11 @@ struct HeatmapExportView: View {
                 stops: {
                     let h = ThemeStore.shared.current.heatmapBaseHue
                     return [
-                        .init(color: emptyKeyColor, location: 0.00),
-                        .init(color: Color(hue: h,            saturation: 0.75, brightness: 0.82), location: 0.15),
-                        .init(color: Color(hue: h * 0.60,     saturation: 0.75, brightness: 0.82), location: 0.45),
-                        .init(color: Color(hue: h * 0.22,     saturation: 0.75, brightness: 0.82), location: 0.75),
-                        .init(color: Color(hue: 0.00,          saturation: 0.75, brightness: 0.82), location: 1.00),
+                        .init(color: emptyKeyColor,             location: 0.00),
+                        .init(color: heatColor(hue: h),         location: 0.15),
+                        .init(color: heatColor(hue: h * 0.60),  location: 0.45),
+                        .init(color: heatColor(hue: h * 0.22),  location: 0.75),
+                        .init(color: heatColor(hue: 0.00),      location: 1.00),
                     ]
                 }(),
                 startPoint: .leading,


### PR DESCRIPTION
Closes #228

## Summary
- **`KeyboardHeatmapView`**: extracted `heatColor(hue:)` helper in both view structs. Dark mode uses `brightness: 0.92, saturation: 0.65`; light mode keeps the original `0.82 / 0.75`. Applied to `heatCell`, `kleHeatCell`, and the legend gradient (3 sites per struct).
- **`ActivityCalendarView`**: added `@Environment(\.colorScheme)`. Dark mode raises the four green intensity levels to `0.40 / 0.60 / 0.80 / 1.00` so low-activity cells remain visible on dark backgrounds.
- Charts (`Charts+*.swift`) and `ThemeStore` are untouched — they already use semantic/adaptive colors.

## Test plan
- [ ] Toggle System Preferences → Appearance between Light and Dark
- [ ] Open heatmap tab — key colors and legend gradient should look softer/brighter in dark mode
- [ ] Open Activity tab — calendar cells should be clearly visible in both modes
- [ ] Verify all six `ChartTheme` hues look correct in both modes