### PR TITLE
refactor: extract KeyMetricsQuery from KeyCountStore (#225)

### DIFF
--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -3,682 +3,150 @@ import GRDB
 import KeyLensCore
 
 // MARK: - Activity & frequency queries
-// Read-only queries for keystroke counts, distributions, and n-gram frequencies.
+// Read-only queries are delegated to KeyMetricsQuery (constructed as a snapshot inside queue.sync).
 
 extension KeyCountStore {
 
-    /// Today's top limit keys sorted descending.
     func todayTopKeys(limit: Int = 10) -> [(key: String, count: Int)] {
-        queue.sync { topEntries(dailyKeyCountsLocked(for: todayKey), limit: limit) }
+        queue.sync { makeQuery().todayTopKeys(limit: limit) }
     }
 
-    /// Today's total keystroke count (SQLite + pending).
     var todayCount: Int {
-        queue.sync { dailyTotalLocked(for: todayKey) }
+        queue.sync { makeQuery().todayCount }
     }
 
-    /// Hourly keystroke counts for a given date (24-element array, index = hour 0–23).
     func hourlyCounts(for date: String) -> [Int] {
-        queue.sync {
-            var result = [Int](repeating: 0, count: 24)
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT hour, count FROM hourly_counts WHERE date = ?", arguments: [date])
-               }) {
-                for row in rows {
-                    let h: Int = row["hour"]
-                    if h < 24 { result[h] += (row["count"] as Int) }
-                }
-            }
-            for (h, v) in pending.hourly[date, default: [:]] where h < 24 { result[h] += v }
-            return result
-        }
+        queue.sync { makeQuery().hourlyCounts(for: date) }
     }
 
-    /// Shortcut efficiency for today: shortcuts / (shortcuts + mouse clicks), or nil if no data.
     func shortcutEfficiencyToday() -> Double? {
-        queue.sync {
-            let shortcuts = store.shortcuts.dailyModifiedCount[todayKey] ?? 0
-            let dayCounts = dailyKeyCountsLocked(for: todayKey)
-            let mouseClicks = dayCounts.filter { $0.key.hasPrefix("🖱") }.values.reduce(0, +)
-            let total = shortcuts + mouseClicks
-            guard total > 0 else { return nil }
-            return Double(shortcuts) / Double(total) * 100.0
-        }
+        queue.sync { makeQuery().shortcutEfficiencyToday() }
     }
 
-    /// Top modifier+key combos sorted descending. Optional prefix filter (e.g. "⌘").
     func topModifiedKeys(prefix: String = "", limit: Int = 20) -> [(key: String, count: Int)] {
-        queue.sync {
-            let filtered = prefix.isEmpty
-                ? store.shortcuts.modifiedCounts
-                : store.shortcuts.modifiedCounts.filter { $0.key.hasPrefix(prefix) }
-            return topEntries(filtered, limit: limit)
-        }
+        queue.sync { makeQuery().topModifiedKeys(prefix: prefix, limit: limit) }
     }
 
-    /// Top-N keys by cumulative count, sorted descending.
     func topKeys(limit: Int = 10) -> [(key: String, count: Int)] {
-        queue.sync { topEntries(store.counts, limit: limit) }
+        queue.sync { makeQuery().topKeys(limit: limit) }
     }
 
-    /// Top-N apps by cumulative keystroke count, sorted descending.
     func topApps(limit: Int = 20) -> [(app: String, count: Int)] {
-        queue.sync { topEntries(store.appTracker.appCounts, limit: limit) }
+        queue.sync { makeQuery().topApps(limit: limit) }
     }
 
-    /// Top-N devices by cumulative keystroke count, sorted descending.
     func topDevices(limit: Int = 20) -> [(device: String, count: Int)] {
-        queue.sync { topEntries(store.appTracker.deviceCounts, limit: limit) }
+        queue.sync { makeQuery().topDevices(limit: limit) }
     }
 
-    /// Per-app ergonomic scores for apps with at least minKeystrokes total keystrokes.
     func appErgonomicScores(minKeystrokes: Int = 100) -> [(app: String, score: Double, keystrokes: Int)] {
-        queue.sync {
-            store.appTracker.appCounts
-                .filter { $0.value >= minKeystrokes }
-                .compactMap { (app, keystrokes) -> (app: String, score: Double, keystrokes: Int)? in
-                    let bigrams = store.appTracker.appTotalBigramCount[app] ?? 0
-                    guard bigrams > 0 else { return nil }
-                    let score = KeyMetricsComputation.ergonomicScore(
-                        sfCount:     store.appTracker.appSameFingerCount[app]       ?? 0,
-                        hsCount:     store.appTracker.appHighStrainBigramCount[app] ?? 0,
-                        altCount:    store.appTracker.appHandAlternationCount[app]  ?? 0,
-                        bigramCount: bigrams
-                    )
-                    return (app: app, score: score, keystrokes: keystrokes)
-                }
-                .sorted { $0.score > $1.score }
-        }
+        queue.sync { makeQuery().appErgonomicScores(minKeystrokes: minKeystrokes) }
     }
 
-    /// Per-device ergonomic scores for devices with at least minKeystrokes total keystrokes.
     func deviceErgonomicScores(minKeystrokes: Int = 100) -> [(device: String, score: Double, keystrokes: Int)] {
-        queue.sync {
-            store.appTracker.deviceCounts
-                .filter { $0.value >= minKeystrokes }
-                .compactMap { (device, keystrokes) -> (device: String, score: Double, keystrokes: Int)? in
-                    let bigrams = store.appTracker.deviceTotalBigramCount[device] ?? 0
-                    guard bigrams > 0 else { return nil }
-                    let score = KeyMetricsComputation.ergonomicScore(
-                        sfCount:     store.appTracker.deviceSameFingerCount[device]       ?? 0,
-                        hsCount:     store.appTracker.deviceHighStrainBigramCount[device] ?? 0,
-                        altCount:    store.appTracker.deviceHandAlternationCount[device]  ?? 0,
-                        bigramCount: bigrams
-                    )
-                    return (device: device, score: score, keystrokes: keystrokes)
-                }
-                .sorted { $0.score > $1.score }
-        }
+        queue.sync { makeQuery().deviceErgonomicScores(minKeystrokes: minKeystrokes) }
     }
 
-    /// Today's top apps sorted descending.
     func todayTopApps(limit: Int = 10) -> [(app: String, count: Int)] {
-        let today = todayKey
-        return queue.sync {
-            var result: [String: Int] = [:]
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT app, count FROM daily_apps WHERE date = ?", arguments: [today])
-               }) {
-                for row in rows { result[row["app"], default: 0] += (row["count"] as Int) }
-            }
-            for (a, v) in pending.dailyApps[today, default: [:]] { result[a, default: 0] += v }
-            return topEntries(result, limit: limit)
-        }
+        queue.sync { makeQuery().todayTopApps(limit: limit) }
     }
 
-    /// Today's top devices sorted descending.
     func todayTopDevices(limit: Int = 10) -> [(device: String, count: Int)] {
-        let today = todayKey
-        return queue.sync {
-            var result: [String: Int] = [:]
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT device, count FROM daily_devices WHERE date = ?", arguments: [today])
-               }) {
-                for row in rows { result[row["device"], default: 0] += (row["count"] as Int) }
-            }
-            for (d, v) in pending.dailyDevices[today, default: [:]] { result[d, default: 0] += v }
-            return topEntries(result, limit: limit)
-        }
+        queue.sync { makeQuery().todayTopDevices(limit: limit) }
     }
 
-    /// Full cumulative bigram frequency table. Used by ErgonomicSnapshot / LayoutComparison.
     var allBigramCounts: [String: Int] {
-        queue.sync { store.ergonomics.bigramCounts }
+        queue.sync { makeQuery().allBigramCounts }
     }
 
-    /// Full cumulative per-key keystroke counts.
     var allKeyCounts: [String: Int] {
-        queue.sync { store.counts }
+        queue.sync { makeQuery().allKeyCounts }
     }
 
-    /// Top-N bigrams by cumulative count.
     func topBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
-        queue.sync { topEntries(store.ergonomics.bigramCounts, limit: limit) }
+        queue.sync { makeQuery().topBigrams(limit: limit) }
     }
 
-    /// Today's top bigrams.
     func todayTopBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
-        let today = todayKey
-        return queue.sync {
-            var result: [String: Int] = [:]
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, count FROM daily_bigrams WHERE date = ?", arguments: [today])
-               }) {
-                for row in rows { result[row["bigram"], default: 0] += (row["count"] as Int) }
-            }
-            for (b, v) in pending.dailyBigrams[today, default: [:]] { result[b, default: 0] += v }
-            return topEntries(result, limit: limit)
-        }
+        queue.sync { makeQuery().todayTopBigrams(limit: limit) }
     }
 
-    /// Top-N trigrams by cumulative frequency.
     func topTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
-        queue.sync { topEntries(store.ergonomics.trigramCounts, limit: limit) }
+        queue.sync { makeQuery().topTrigrams(limit: limit) }
     }
 
-    /// Today's top trigrams.
     func todayTopTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
-        let today = todayKey
-        return queue.sync {
-            var result: [String: Int] = [:]
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT trigram, count FROM daily_trigrams WHERE date = ?", arguments: [today])
-               }) {
-                for row in rows { result[row["trigram"], default: 0] += (row["count"] as Int) }
-            }
-            for (t, v) in pending.dailyTrigrams[today, default: [:]] { result[t, default: 0] += v }
-            return topEntries(result, limit: limit)
-        }
+        queue.sync { makeQuery().todayTopTrigrams(limit: limit) }
     }
 
-    /// Average IKI (ms) for a bigram. Returns nil if no samples exist (Issue #24).
     func avgBigramIKI(for bigram: String) -> Double? {
-        queue.sync {
-            var sum: Double = 0
-            var count: Int  = 0
-            if let db = dbQueue,
-               let row = try? db.read({ db in
-                   try Row.fetchOne(db, sql: "SELECT iki_sum, iki_count FROM bigram_iki WHERE bigram = ?", arguments: [bigram])
-               }) {
-                sum   = row["iki_sum"]   ?? 0
-                count = row["iki_count"] ?? 0
-            }
-            if let p = pending.bigramIKI[bigram] { sum += p.sum; count += p.count }
-            guard count > 0 else { return nil }
-            return sum / Double(count)
-        }
+        queue.sync { makeQuery().avgBigramIKI(for: bigram) }
     }
 
-    /// Bigrams ranked by training priority (Issue #85).
-    ///
-    /// Reads all bigram IKI data from SQLite + pending, computes
-    /// `BigramScore` for each, and returns the top-k candidates.
-    ///
-    /// - Parameters:
-    ///   - minCount: Minimum observation count to include a bigram (default: 5).
-    ///   - topK:     Maximum results returned (default: 10).
     func rankedBigramsForTraining(minCount: Int = 5, topK: Int = 10) -> [BigramScore] {
-        queue.sync {
-            var merged: [String: (sum: Double, count: Int)] = [:]
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let key: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    merged[key] = (sum: sum, count: cnt)
-                }
-            }
-
-            for (bigram, p) in pending.bigramIKI {
-                let e = merged[bigram] ?? (sum: 0, count: 0)
-                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-
-            let candidates = merged.compactMap { bigram, data -> BigramScore? in
-                guard data.count > 0 else { return nil }
-                let meanIKI = data.sum / Double(data.count)
-                return BigramScore(bigram: bigram, meanIKI: meanIKI, count: data.count)
-            }
-
-            return BigramScore.topCandidates(candidates, minCount: minCount, topK: topK)
-        }
+        queue.sync { makeQuery().rankedBigramsForTraining(minCount: minCount, topK: topK) }
     }
 
-    /// Trigrams ranked by training priority (Issue #89).
-    ///
-    /// Estimates trigram latency from the two constituent bigram mean IKIs:
-    ///   estimatedIKI("t→h→e") = meanIKI("t→h") + meanIKI("h→e")
-    ///
-    /// Trigrams where either constituent bigram has no IKI data are excluded.
-    ///
-    /// - Parameters:
-    ///   - minCount: Minimum observation count to include a trigram (default: 5).
-    ///   - topK:     Maximum results returned (default: 10).
     func rankedTrigramsForTraining(minCount: Int = 5, topK: Int = 10) -> [TrigramScore] {
-        queue.sync {
-            // Build merged bigram mean IKI (same approach as rankedBigramsForTraining).
-            var mergedBigram: [String: (sum: Double, count: Int)] = [:]
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let key: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    mergedBigram[key] = (sum: sum, count: cnt)
-                }
-            }
-            for (bigram, p) in pending.bigramIKI {
-                let e = mergedBigram[bigram] ?? (sum: 0, count: 0)
-                mergedBigram[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-            let bigramMeanIKI: [String: Double] = mergedBigram.compactMapValues { data -> Double? in
-                guard data.count > 0 else { return nil }
-                return data.sum / Double(data.count)
-            }
-
-            // Merge all-time trigram counts with any pending session data.
-            var counts: [String: Int] = store.ergonomics.trigramCounts
-            for (_, dayMap) in pending.dailyTrigrams {
-                for (t, v) in dayMap { counts[t, default: 0] += v }
-            }
-
-            // Build candidates: estimate IKI from constituent bigrams.
-            let candidates: [TrigramScore] = counts.compactMap { trigram, count -> TrigramScore? in
-                guard let t = Trigram.parse(trigram),
-                      let ikiAB = bigramMeanIKI[t.leadingBigram],
-                      let ikiBC = bigramMeanIKI[t.trailingBigram]
-                else { return nil }
-                return TrigramScore(trigram: trigram, estimatedIKI: ikiAB + ikiBC, count: count)
-            }
-
-            return TrigramScore.topCandidates(candidates, minCount: minCount, topK: topK)
-        }
+        queue.sync { makeQuery().rankedTrigramsForTraining(minCount: minCount, topK: topK) }
     }
 
-    /// Returns a dictionary of all bigram keys to their current mean IKI in milliseconds (Issue #84).
-    ///
-    /// Used to compute the "after" IKI when displaying before/after training history.
-    /// Merges persisted SQLite data with any pending in-memory IKI deltas.
-    ///
-    /// - Returns: `[bigramKey: meanIKI]` for every bigram with at least one observation.
     func allBigramIKI() -> [String: Double] {
-        queue.sync {
-            var merged: [String: (sum: Double, count: Int)] = [:]
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let key: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    merged[key] = (sum: sum, count: cnt)
-                }
-            }
-
-            for (bigram, p) in pending.bigramIKI {
-                let e = merged[bigram] ?? (sum: 0, count: 0)
-                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-
-            return merged.compactMapValues { data -> Double? in
-                guard data.count > 0 else { return nil }
-                return data.sum / Double(data.count)
-            }
-        }
+        queue.sync { makeQuery().allBigramIKI() }
     }
 
-    /// Average IKI broken down by finger (Issue #104).
-    ///
-    /// Aggregates `bigram_iki` data by mapping the destination key of each bigram
-    /// to its finger via `ANSILayout`. IKI is attributed to the receiving finger —
-    /// how fast each finger responds when it is the next key to press.
-    ///
-    /// - Returns: Array of `(finger, avgIKI)` for fingers with data, sorted slowest-first.
     func ikiPerFinger() -> [(finger: String, avgIKI: Double)] {
-        let layout = ANSILayout()
-        var perFinger: [String: (sum: Double, count: Int)] = [:]
-
-        queue.sync {
-            var merged: [String: (sum: Double, count: Int)] = [:]
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let key: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    merged[key] = (sum: sum, count: cnt)
-                }
-            }
-            for (bigram, p) in pending.bigramIKI {
-                let e = merged[bigram] ?? (sum: 0, count: 0)
-                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-
-            for (bigramKey, data) in merged where data.count > 0 {
-                guard let bigram = Bigram.parse(bigramKey),
-                      let finger = layout.finger(for: bigram.to) else { continue }
-                let e = perFinger[finger.rawValue] ?? (sum: 0, count: 0)
-                perFinger[finger.rawValue] = (sum: e.sum + data.sum, count: e.count + data.count)
-            }
-        }
-
-        return perFinger
-            .compactMap { finger, data -> (finger: String, avgIKI: Double)? in
-                guard data.count > 0 else { return nil }
-                return (finger: finger, avgIKI: data.sum / Double(data.count))
-            }
-            .sorted { $0.avgIKI > $1.avgIKI }
+        queue.sync { makeQuery().ikiPerFinger() }
     }
 
-    /// Top N slowest bigrams by average IKI (Issue #103).
-    ///
-    /// - Parameters:
-    ///   - minCount: Minimum observation count; bigrams below this are excluded (default: 5).
-    ///   - limit:    Maximum number of results (default: 20).
-    /// - Returns: Array of `(bigram, avgIKI)` sorted descending by avg IKI (slowest first).
     func slowestBigrams(minCount: Int = 5, limit: Int = 20) -> [(bigram: String, avgIKI: Double)] {
-        queue.sync {
-            var merged: [String: (sum: Double, count: Int)] = [:]
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let key: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    merged[key] = (sum: sum, count: cnt)
-                }
-            }
-
-            for (bigram, p) in pending.bigramIKI {
-                let e = merged[bigram] ?? (sum: 0, count: 0)
-                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-
-            return merged
-                .compactMap { bigram, data -> (bigram: String, avgIKI: Double)? in
-                    guard data.count >= minCount else { return nil }
-                    return (bigram: bigram, avgIKI: data.sum / Double(data.count))
-                }
-                .sorted { $0.avgIKI > $1.avgIKI }
-                .prefix(limit)
-                .map { $0 }
-        }
+        queue.sync { makeQuery().slowestBigrams(minCount: minCount, limit: limit) }
     }
 
-    /// Incoming and outgoing transitions for a specific key, ranked by avg IKI (Issue #98).
-    ///
-    /// - Parameters:
-    ///   - key:      The target key to inspect (case-sensitive, matches on-disk format).
-    ///   - minCount: Minimum sample count; transitions below this threshold are excluded (default: 3).
-    ///   - limit:    Maximum results per direction (default: 15).
-    /// - Returns: Tuple of incoming (`*→key`) and outgoing (`key→*`) arrays, each sorted slowest-first.
     func keyTransitions(
         for key: String,
         minCount: Int = 3,
         limit: Int = 15
     ) -> (incoming: [(bigram: String, avgIKI: Double, count: Int)],
           outgoing: [(bigram: String, avgIKI: Double, count: Int)]) {
-        queue.sync {
-            var merged: [String: (sum: Double, count: Int)] = [:]
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
-               }) {
-                for row in rows {
-                    let k: String = row["bigram"]
-                    let sum: Double = row["iki_sum"]
-                    let cnt: Int    = row["iki_count"]
-                    merged[k] = (sum: sum, count: cnt)
-                }
-            }
-            for (bigram, p) in pending.bigramIKI {
-                let e = merged[bigram] ?? (sum: 0, count: 0)
-                merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
-            }
-
-            func toEntry(_ kv: (key: String, value: (sum: Double, count: Int)))
-                -> (bigram: String, avgIKI: Double, count: Int)? {
-                guard kv.value.count >= minCount else { return nil }
-                return (bigram: kv.key, avgIKI: kv.value.sum / Double(kv.value.count), count: kv.value.count)
-            }
-
-            let incomingSuffix = "→\(key)"
-            let outgoingPrefix = "\(key)→"
-
-            let incoming = merged
-                .filter { $0.key.hasSuffix(incomingSuffix) }
-                .compactMap { toEntry($0) }
-                .sorted { $0.avgIKI > $1.avgIKI }
-                .prefix(limit).map { $0 }
-
-            let outgoing = merged
-                .filter { $0.key.hasPrefix(outgoingPrefix) }
-                .compactMap { toEntry($0) }
-                .sorted { $0.avgIKI > $1.avgIKI }
-                .prefix(limit).map { $0 }
-
-            return (incoming: incoming, outgoing: outgoing)
-        }
+        queue.sync { makeQuery().keyTransitions(for: key, minCount: minCount, limit: limit) }
     }
 
-    /// All daily totals sorted ascending by date.
     func dailyTotals() -> [(date: String, total: Int)] {
-        queue.sync {
-            guard let db = dbQueue else { return [] }
-            var map: [String: Int] = [:]
-            if let rows = try? db.read({ db in
-                try Row.fetchAll(db, sql: "SELECT date, SUM(count) as total FROM daily_keys GROUP BY date ORDER BY date")
-            }) {
-                for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
-            }
-            for (date, keys) in pending.dailyKeys { map[date, default: 0] += keys.values.reduce(0, +) }
-            return map.sorted { $0.key < $1.key }.map { (date: $0.key, total: $0.value) }
-        }
+        queue.sync { makeQuery().dailyTotals() }
     }
 
-    /// Per-day keystroke totals for the last N calendar days (oldest first).
     func dailyTotals(last days: Int) -> [(date: String, count: Int)] {
-        let cal = Calendar.current
-        let cutoffDate = cal.date(byAdding: .day, value: -(days - 1), to: Date()) ?? Date()
-        return queue.sync {
-            guard let db = dbQueue else { return [] }
-            let cutoff = Self.dayFormatter.string(from: cutoffDate)
-            var map: [String: Int] = [:]
-            if let rows = try? db.read({ db in
-                try Row.fetchAll(db, sql: """
-                    SELECT date, SUM(count) as total FROM daily_keys WHERE date >= ? GROUP BY date
-                    """, arguments: [cutoff])
-            }) {
-                for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
-            }
-            for (date, keys) in pending.dailyKeys where date >= cutoff {
-                map[date, default: 0] += keys.values.reduce(0, +)
-            }
-            return (0..<days).reversed().compactMap { offset -> (String, Int)? in
-                guard let date = cal.date(byAdding: .day, value: -offset, to: Date()) else { return nil }
-                let key = Self.dayFormatter.string(from: date)
-                return (key, map[key] ?? 0)
-            }
-        }
+        queue.sync { makeQuery().dailyTotals(last: days) }
     }
 
-    /// Average keystroke count per (weekday, hour) cell across all recorded dates.
-    /// weekday: 0 = Sunday … 6 = Saturday  |  hour: 0–23
-    /// Used by the Weekly Activity Heatmap (Issue #78).
     func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double)] {
-        queue.sync {
-            // sums[weekday][hour] = cumulative keystroke count
-            // days[weekday]       = set of distinct dates seen for that weekday
-            var sums = [Int: [Int: Int]]()
-            var days = [Int: Set<String>]()
-
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: """
-                       SELECT date,
-                              CAST(strftime('%w', date) AS INTEGER) AS weekday,
-                              hour,
-                              count
-                       FROM hourly_counts
-                       """)
-               }) {
-                for row in rows {
-                    let date: String = row["date"]
-                    let wd: Int      = row["weekday"]
-                    let h: Int       = row["hour"]
-                    let c: Int       = row["count"]
-                    guard h < 24 else { continue }
-                    sums[wd, default: [:]][h, default: 0] += c
-                    days[wd, default: []].insert(date)
-                }
-            }
-
-            // Merge pending in-memory data.
-            let cal = Calendar.current
-            for (date, hours) in pending.hourly {
-                guard let d = Self.dayFormatter.date(from: date) else { continue }
-                // Calendar.weekday: 1 = Sunday … 7 = Saturday  →  convert to 0-based
-                let wd = cal.component(.weekday, from: d) - 1
-                days[wd, default: []].insert(date)
-                for (h, v) in hours where h < 24 {
-                    sums[wd, default: [:]][h, default: 0] += v
-                }
-            }
-
-            // Build result ordered by weekday then hour.
-            var result: [(weekday: Int, hour: Int, avgCount: Double)] = []
-            for wd in 0..<7 {
-                let dayCount = days[wd]?.count ?? 0
-                for h in 0..<24 {
-                    let sum = sums[wd]?[h] ?? 0
-                    let avg = dayCount > 0 ? Double(sum) / Double(dayCount) : 0.0
-                    result.append((weekday: wd, hour: h, avgCount: avg))
-                }
-            }
-            return result
-        }
+        queue.sync { makeQuery().hourlyCountsByDayOfWeek() }
     }
 
-    /// Aggregate hourly keystroke counts across all recorded dates.
     func hourlyDistribution() -> [Int] {
-        queue.sync {
-            var result = [Int](repeating: 0, count: 24)
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db, sql: "SELECT hour, SUM(count) as total FROM hourly_counts GROUP BY hour")
-               }) {
-                for row in rows {
-                    let h: Int = row["hour"]
-                    if h < 24 { result[h] += (row["total"] as Int) }
-                }
-            }
-            for (_, hours) in pending.hourly { for (h, v) in hours where h < 24 { result[h] += v } }
-            return result
-        }
+        queue.sync { makeQuery().hourlyDistribution() }
     }
 
-    /// Aggregate total keystrokes by calendar month ("yyyy-MM"), sorted ascending.
     func monthlyTotals() -> [(month: String, total: Int)] {
-        queue.sync {
-            guard let db = dbQueue else { return [] }
-            var map: [String: Int] = [:]
-            if let rows = try? db.read({ db in
-                try Row.fetchAll(db, sql: """
-                    SELECT SUBSTR(date,1,7) as month, SUM(count) as total
-                    FROM daily_keys GROUP BY month ORDER BY month
-                    """)
-            }) {
-                for row in rows { map[row["month"], default: 0] = (row["total"] as Int) }
-            }
-            for (date, keys) in pending.dailyKeys {
-                guard date.count >= 7 else { continue }
-                let month = String(date.prefix(7))
-                map[month, default: 0] += keys.values.reduce(0, +)
-            }
-            return map.sorted { $0.key < $1.key }.map { (month: $0.key, total: $0.value) }
-        }
+        queue.sync { makeQuery().monthlyTotals() }
     }
 
-    /// Keystroke counts broken down by KeyType, sorted descending.
     func countsByType() -> [(type: KeyType, count: Int)] {
-        queue.sync {
-            var totals: [KeyType: Int] = [:]
-            for (key, count) in store.counts {
-                totals[KeyType.classify(key), default: 0] += count
-            }
-            return KeyType.allCases
-                .compactMap { t in totals[t].map { (type: t, count: $0) } }
-                .filter { $0.count > 0 }
-                .sorted { $0.count > $1.count }
-        }
+        queue.sync { makeQuery().countsByType() }
     }
 
-    /// Top limit keys per day over the most recent recentDays days.
     func topKeysPerDay(limit: Int = 10, recentDays: Int = 14) -> [(date: String, key: String, count: Int)] {
-        queue.sync {
-            guard let db = dbQueue else { return [] }
-            let cal = Calendar.current
-            let cutoffDate = cal.date(byAdding: .day, value: -recentDays, to: Date()) ?? Date()
-            let cutoff = Self.dayFormatter.string(from: cutoffDate)
-
-            // Load all rows in range
-            var dateMap: [String: [String: Int]] = [:]
-            if let rows = try? db.read({ db in
-                try Row.fetchAll(db, sql: "SELECT date, key, count FROM daily_keys WHERE date >= ? ORDER BY date", arguments: [cutoff])
-            }) {
-                for row in rows {
-                    dateMap[row["date"], default: [:]][row["key"], default: 0] += (row["count"] as Int)
-                }
-            }
-            for (date, keys) in pending.dailyKeys where date >= cutoff {
-                for (k, v) in keys { dateMap[date, default: [:]][k, default: 0] += v }
-            }
-
-            // Compute top keys across the range
-            var combined: [String: Int] = [:]
-            for (_, keys) in dateMap { for (k, v) in keys { combined[k, default: 0] += v } }
-            let topKeyNames = topEntries(combined, limit: limit).map { $0.0 }
-
-            let dates = Array(dateMap.keys.sorted().suffix(recentDays))
-            var result: [(date: String, key: String, count: Int)] = []
-            for date in dates {
-                let dayCounts = dateMap[date] ?? [:]
-                for key in topKeyNames {
-                    result.append((date: date, key: key, count: dayCounts[key] ?? 0))
-                }
-            }
-            return result
-        }
+        queue.sync { makeQuery().topKeysPerDay(limit: limit, recentDays: recentDays) }
     }
 
-    /// Last N IKI values from the live ring buffer (main-thread safe snapshot).
     func latestIKIs() -> [(key: String, iki: Double)] {
-        queue.sync { recentIKIs }
+        queue.sync { makeQuery().latestIKIs() }
     }
 
     // MARK: - Manual WPM measurement (Issue #150)
+    // Write operations remain on KeyCountStore.
 
-    /// Starts a new WPM measurement session. Resets any previous session.
     func startWPMMeasurement() {
         queue.sync {
             wpmSessionStart = Date()
@@ -686,8 +154,6 @@ extension KeyCountStore {
         }
     }
 
-    /// Stops the active session and returns the result.
-    /// Returns nil if no session was running.
     func stopWPMMeasurement() -> (wpm: Double, duration: TimeInterval, keystrokes: Int)? {
         queue.sync {
             guard let start = wpmSessionStart else { return nil }
@@ -701,30 +167,11 @@ extension KeyCountStore {
         }
     }
 
-    /// Whether a WPM measurement session is currently active.
     var isWPMMeasuring: Bool {
-        queue.sync { wpmSessionStart != nil }
+        queue.sync { makeQuery().isWPMMeasuring }
     }
 
-    /// All keys sorted by cumulative count descending, including today's count.
     func allEntries() -> [(key: String, total: Int, today: Int)] {
-        queue.sync {
-            let todayData = dailyKeyCountsLocked(for: todayKey)
-            return store.counts.sorted { $0.value > $1.value }
-                .map { (key: $0.key, total: $0.value, today: todayData[$0.key] ?? 0) }
-        }
-    }
-}
-
-// MARK: - Private helpers
-
-extension KeyCountStore {
-
-    /// Returns the top-N entries from a [String: Int] dictionary, sorted by value descending.
-    /// Must be called from inside `queue.sync`.
-    func topEntries(_ dict: [String: Int], limit: Int) -> [(String, Int)] {
-        dict.sorted { $0.value > $1.value }
-            .prefix(limit)
-            .map { ($0.key, $0.value) }
+        queue.sync { makeQuery().allEntries() }
     }
 }

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -3,323 +3,116 @@ import GRDB
 import KeyLensCore
 
 // MARK: - Ergonomic queries
-// Read-only ergonomic metrics derived from the stored bigram/keystroke data.
+// Read-only queries are delegated to KeyMetricsQuery (constructed as a snapshot inside queue.sync).
 
 extension KeyCountStore {
 
-    /// Average inter-keystroke interval (ms). Returns nil if fewer than 1 sample.
     var averageIntervalMs: Double? {
-        queue.sync { store.activity.avgIntervalCount > 0 ? store.activity.avgIntervalMs : nil }
+        queue.sync { makeQuery().averageIntervalMs }
     }
 
-    /// Estimated typing speed in WPM. Based on the standard definition: 1 word = 5 keystrokes.
     var estimatedWPM: Double? {
-        guard let ms = averageIntervalMs, ms > 0 else { return nil }
-        return KeyMetricsComputation.wpm(avgIntervalMs: ms)
+        queue.sync { makeQuery().estimatedWPM }
     }
 
-    /// Rolling WPM from keystrokes in the last `windowSeconds` using the recentIKIs ring buffer.
-    /// Returns 0 if no keystroke was received in the last 2 seconds (idle decay).
     func rollingWPM(windowSeconds: Double = 5.0) -> Double {
-        queue.sync {
-            guard let last = store.activity.lastInputTime,
-                  Date().timeIntervalSince(last) <= AppConfiguration.wpmIdleDecaySecs else { return 0.0 }
-            let windowMs = windowSeconds * 1000.0
-            var totalMs = 0.0
-            var count = 0
-            for entry in recentIKIs.reversed() {
-                guard entry.iki > 0 else { continue }
-                guard totalMs + entry.iki <= windowMs else { break }
-                totalMs += entry.iki
-                count += 1
-            }
-            guard count > 0, totalMs > 0 else { return 0.0 }
-            return KeyMetricsComputation.wpm(avgIntervalMs: totalMs / Double(count))
-        }
+        queue.sync { makeQuery().rollingWPM(windowSeconds: windowSeconds) }
     }
 
-    /// Cumulative backspace rate: Delete count / total keystrokes × 100 (%).
     var backspaceRate: Double? {
-        queue.sync {
-            let total = store.counts.values.reduce(0, +)
-            guard total > 0 else { return nil }
-            return Double(store.counts["Delete", default: 0]) / Double(total) * 100.0
-        }
+        queue.sync { makeQuery().backspaceRate }
     }
 
-    /// Today's backspace rate (%).
     var todayBackspaceRate: Double? {
-        queue.sync {
-            let dayCounts = dailyKeyCountsLocked(for: todayKey)
-            let total = dayCounts.values.reduce(0, +)
-            guard total > 0 else { return nil }
-            return Double(dayCounts["Delete", default: 0]) / Double(total) * 100.0
-        }
+        queue.sync { makeQuery().todayBackspaceRate }
     }
 
-    /// Returns per-day backspace rate sorted ascending. Days with zero keystrokes are excluded.
     func dailyBackspaceRates() -> [(date: String, rate: Double)] {
-        queue.sync {
-            guard let db = dbQueue else { return [] }
-            let today = todayKey
-            // Historical dates (before today) via a single SQL aggregation
-            var result: [(date: String, rate: Double)] = []
-            if let rows = try? db.read({ db in
-                try Row.fetchAll(db, sql: """
-                    SELECT date,
-                           SUM(count) as total,
-                           SUM(CASE WHEN key = 'Delete' THEN count ELSE 0 END) as deletes
-                    FROM daily_keys WHERE date < ?
-                    GROUP BY date HAVING total > 0 ORDER BY date
-                    """, arguments: [today])
-            }) {
-                for row in rows {
-                    let total: Int = row["total"]
-                    guard total > 0 else { continue }
-                    result.append((row["date"], Double(row["deletes"] as Int) / Double(total) * 100.0))
-                }
-            }
-            // Today: merge SQL + pending for accuracy
-            let todayCounts = dailyKeyCountsLocked(for: today)
-            let todayTotal  = todayCounts.values.reduce(0, +)
-            if todayTotal > 0 {
-                let bs = todayCounts["Delete", default: 0]
-                result.append((today, Double(bs) / Double(todayTotal) * 100.0))
-            }
-            return result
-        }
+        queue.sync { makeQuery().dailyBackspaceRates() }
     }
 
-    /// Returns per-day estimated WPM sorted by date ascending.
     func dailyWPM() -> [(date: String, wpm: Double)] {
-        queue.sync {
-            store.activity.dailyAvgIntervalMs.compactMap { date, avgMs -> (date: String, wpm: Double)? in
-                guard let count = store.activity.dailyAvgIntervalCount[date], count > 0, avgMs > 0 else { return nil }
-                return (date, KeyMetricsComputation.wpm(avgIntervalMs: avgMs))
-            }
-            .sorted { $0.date < $1.date }
-        }
+        queue.sync { makeQuery().dailyWPM() }
     }
 
-    /// Today's minimum inter-keystroke interval (ms, ≤1000ms only).
     var todayMinIntervalMs: Double? {
-        let key = todayKey
-        return queue.sync { store.activity.dailyMinIntervalMs[key] }
+        queue.sync { makeQuery().todayMinIntervalMs }
     }
 
-    /// Cumulative same-finger bigram rate.
     var sameFingerRate: Double? {
-        queue.sync {
-            guard store.ergonomics.totalBigramCount > 0 else { return nil }
-            return Double(store.ergonomics.sameFingerCount) / Double(store.ergonomics.totalBigramCount)
-        }
+        queue.sync { makeQuery().sameFingerRate }
     }
 
-    /// Today's same-finger bigram rate.
     var todaySameFingerRate: Double? {
-        let today = todayKey
-        return queue.sync {
-            let total = store.ergonomics.dailyTotalBigramCount[today] ?? 0
-            guard total > 0 else { return nil }
-            return Double(store.ergonomics.dailySameFingerCount[today] ?? 0) / Double(total)
-        }
+        queue.sync { makeQuery().todaySameFingerRate }
     }
 
-    /// Cumulative hand-alternation rate.
     var handAlternationRate: Double? {
-        queue.sync {
-            guard store.ergonomics.totalBigramCount > 0 else { return nil }
-            return Double(store.ergonomics.handAlternationCount) / Double(store.ergonomics.totalBigramCount)
-        }
+        queue.sync { makeQuery().handAlternationRate }
     }
 
-    /// Today's hand-alternation rate.
     var todayHandAlternationRate: Double? {
-        let today = todayKey
-        return queue.sync {
-            let total = store.ergonomics.dailyTotalBigramCount[today] ?? 0
-            guard total > 0 else { return nil }
-            return Double(store.ergonomics.dailyHandAlternationCount[today] ?? 0) / Double(total)
-        }
+        queue.sync { makeQuery().todayHandAlternationRate }
     }
 
-    /// Cumulative alternation reward score (Issue #25).
     var alternationRewardScore: Double {
-        queue.sync { store.ergonomics.alternationRewardScore }
+        queue.sync { makeQuery().alternationRewardScore }
     }
 
-    /// Cumulative thumb imbalance ratio (Issue #26).
     var thumbImbalanceRatio: Double? {
-        queue.sync {
-            LayoutRegistry.shared.thumbImbalanceDetector
-                .imbalanceRatio(counts: store.counts, layout: LayoutRegistry.shared)
-        }
+        queue.sync { makeQuery().thumbImbalanceRatio }
     }
 
-    /// Thumb imbalance ratio for a specific day (Issue #26).
     func dailyThumbImbalance(for date: String) -> Double? {
-        queue.sync {
-            let dayCounts = dailyKeyCountsLocked(for: date)
-            guard !dayCounts.isEmpty else { return nil }
-            return LayoutRegistry.shared.thumbImbalanceDetector
-                .imbalanceRatio(counts: dayCounts, layout: LayoutRegistry.shared)
-        }
+        queue.sync { makeQuery().dailyThumbImbalance(for: date) }
     }
 
-    /// Per-day ergonomic rates for Learning Curve visualization (Phase 3).
     func dailyErgonomicRates() -> [(date: String, sameFingerRate: Double, handAltRate: Double, highStrainRate: Double)] {
-        queue.sync {
-            allDatesLocked().compactMap { date in
-                let bigrams = store.ergonomics.dailyTotalBigramCount[date] ?? 0
-                guard bigrams > 0 else { return nil }
-                let sf = Double(store.ergonomics.dailySameFingerCount[date]       ?? 0) / Double(bigrams)
-                let ha = Double(store.ergonomics.dailyHandAlternationCount[date]  ?? 0) / Double(bigrams)
-                let hs = Double(store.ergonomics.dailyHighStrainBigramCount[date] ?? 0) / Double(bigrams)
-                return (date: date, sameFingerRate: sf, handAltRate: ha, highStrainRate: hs)
-            }
-        }
+        queue.sync { makeQuery().dailyErgonomicRates() }
     }
 
-    /// Cumulative high-strain bigram count (Issue #28).
     var highStrainBigramCount: Int {
-        queue.sync { store.ergonomics.highStrainBigramCount }
+        queue.sync { makeQuery().highStrainBigramCount }
     }
 
-    /// Fraction of all bigrams that are high-strain.
     var highStrainBigramRate: Double? {
-        queue.sync {
-            guard store.ergonomics.totalBigramCount > 0 else { return nil }
-            return Double(store.ergonomics.highStrainBigramCount) / Double(store.ergonomics.totalBigramCount)
-        }
+        queue.sync { makeQuery().highStrainBigramRate }
     }
 
-    /// Cumulative high-strain trigram count (Issue #28).
     var highStrainTrigramCount: Int {
-        queue.sync { store.ergonomics.highStrainTrigramCount }
+        queue.sync { makeQuery().highStrainTrigramCount }
     }
 
-    /// Top-N high-strain bigrams by frequency (Issue #28).
     func topHighStrainBigrams(limit: Int = 10) -> [(pair: String, count: Int)] {
-        queue.sync {
-            let detector = LayoutRegistry.shared.highStrainDetector
-            let layout   = LayoutRegistry.shared
-            return store.ergonomics.bigramCounts
-                .filter { pair, _ in
-                    guard let b = Bigram.parse(pair) else { return false }
-                    return detector.isHighStrain(from: b.from, to: b.to, layout: layout)
-                }
-                .sorted { $0.value > $1.value }
-                .prefix(limit)
-                .map { (pair: $0.key, count: $0.value) }
-        }
+        queue.sync { makeQuery().topHighStrainBigrams(limit: limit) }
     }
 
-    /// Thumb efficiency coefficient (Issue #27).
     var thumbEfficiencyCoefficient: Double? {
-        queue.sync {
-            LayoutRegistry.shared.thumbEfficiencyCalculator
-                .coefficient(counts: store.counts, layout: LayoutRegistry.shared)
-        }
+        queue.sync { makeQuery().thumbEfficiencyCoefficient }
     }
 
-
-    /// Unified ergonomic score (0–100) from cumulative keystroke data (Issue #29).
     var currentErgonomicScore: Double {
-        queue.sync {
-            KeyMetricsComputation.ergonomicScore(
-                sfCount:      store.ergonomics.sameFingerCount,
-                hsCount:      store.ergonomics.highStrainBigramCount,
-                altCount:     store.ergonomics.handAlternationCount,
-                bigramCount:  store.ergonomics.totalBigramCount,
-                keyCounts:    store.counts
-            )
-        }
+        queue.sync { makeQuery().currentErgonomicScore }
     }
 
-    /// Inferred typing style based on cumulative data.
     public var currentTypingStyle: TypingStyle {
-        queue.sync { TypingStyleAnalyzer().analyze(keyCounts: store.counts) }
+        queue.sync { makeQuery().currentTypingStyle }
     }
 
-    /// Detected typing rhythm from the recent IKI ring buffer.
     public var currentTypingRhythm: TypingRhythm {
-        queue.sync { TypingRhythmAnalyzer().analyze(ikis: rhythmIKIs) }
+        queue.sync { makeQuery().currentTypingRhythm }
     }
 
-    /// Detected fatigue risk level.
     public var currentFatigueLevel: FatigueLevel {
-        queue.sync {
-            let bigrams = store.ergonomics.totalBigramCount
-            let hsRate = bigrams > 0 ? Double(store.ergonomics.highStrainBigramCount) / Double(bigrams) : 0.0
-            return FatigueRiskModel().analyze(
-                currentAvgIntervalMs:   nil,
-                baselineAvgIntervalMs:  nil,
-                currentHighStrainRate:  hsRate,
-                baselineHighStrainRate: 0.02
-            )
-        }
+        queue.sync { makeQuery().currentFatigueLevel }
     }
 
-    /// Per-hour fatigue curve for today (Issue #63).
-    ///
-    /// Returns hourly WPM and ergonomic rates, merging persisted SQLite data with
-    /// any pending in-memory slices. Hours with no data are omitted.
     func todayHourlyFatigueCurve() -> [HourlyFatigueEntry] {
-        let today = todayKey
-        return queue.sync {
-            var slices: [Int: (ikiSum: Double, ikiCount: Int, ergTotal: Int, ergSF: Int, ergHS: Int)] = [:]
-
-            // Load persisted data from SQLite
-            if let db = dbQueue,
-               let rows = try? db.read({ db in
-                   try Row.fetchAll(db,
-                       sql: "SELECT hour, iki_sum, iki_count, erg_total, erg_sf, erg_hs FROM hourly_ergonomics WHERE date = ?",
-                       arguments: [today])
-               }) {
-                for row in rows {
-                    let h: Int = row["hour"]
-                    slices[h] = (row["iki_sum"], row["iki_count"], row["erg_total"], row["erg_sf"], row["erg_hs"])
-                }
-            }
-
-            // Merge pending (current session, not yet flushed)
-            for (h, sl) in pending.hourlySlices[today, default: [:]] {
-                let e = slices[h] ?? (0, 0, 0, 0, 0)
-                slices[h] = (e.ikiSum   + sl.ikiSum,   e.ikiCount + sl.ikiCount,
-                             e.ergTotal + sl.ergTotal, e.ergSF    + sl.ergSF,
-                             e.ergHS    + sl.ergHS)
-            }
-
-            return slices.compactMap { hour, s -> HourlyFatigueEntry? in
-                guard s.ikiCount > 0 || s.ergTotal > 0 else { return nil }
-                let wpm: Double? = s.ikiCount > 0
-                    ? KeyMetricsComputation.wpm(avgIntervalMs: s.ikiSum / Double(s.ikiCount))
-                    : nil
-                let sfRate: Double? = s.ergTotal > 0 ? Double(s.ergSF) / Double(s.ergTotal) : nil
-                let hsRate: Double? = s.ergTotal > 0 ? Double(s.ergHS) / Double(s.ergTotal) : nil
-                return HourlyFatigueEntry(id: hour, hour: hour, wpm: wpm, sameFingerRate: sfRate, highStrainRate: hsRate)
-            }
-            .sorted { $0.hour < $1.hour }
-        }
+        queue.sync { makeQuery().todayHourlyFatigueCurve() }
     }
 
-    /// Per-day ergonomic scores for trend tracking (Issue #29).
     var dailyErgonomicScore: [String: Double] {
-        queue.sync {
-            var result: [String: Double] = [:]
-            for date in allDatesLocked() {
-                let bigrams = store.ergonomics.dailyTotalBigramCount[date] ?? 0
-                guard bigrams > 0 else { continue }
-                result[date] = KeyMetricsComputation.ergonomicScore(
-                    sfCount:     store.ergonomics.dailySameFingerCount[date]       ?? 0,
-                    hsCount:     store.ergonomics.dailyHighStrainBigramCount[date] ?? 0,
-                    altCount:    store.ergonomics.dailyHandAlternationCount[date]  ?? 0,
-                    bigramCount: bigrams,
-                    keyCounts:   dailyKeyCountsLocked(for: date)
-                )
-            }
-            return result
-        }
+        queue.sync { makeQuery().dailyErgonomicScore }
     }
 }
 
@@ -327,65 +120,9 @@ extension KeyCountStore {
 
 extension KeyCountStore {
 
-    /// Computes same-finger bigram rate and hand-alternation rate for QWERTY, Colemak, and Dvorak,
-    /// applied to the user's actual all-time bigram frequency distribution.
-    ///
-    /// Allows the user to see how their real typing patterns would perform across layouts without
-    /// needing to type on each layout or export data to an external tool.
-    ///
-    /// - Returns: One entry per layout. "Your Layout" is always first; the rest are sorted by ergonomic score descending.
     func layoutEfficiencyScores() -> [LayoutEfficiencyEntry] {
-        let (bigrams, keyCounts) = queue.sync { (store.ergonomics.bigramCounts, store.counts) }
-        guard !bigrams.isEmpty else { return [] }
-        let totalBigrams = bigrams.values.reduce(0, +)
-
-        // Resolve the user's selected heatmap template from persistent storage.
-        // All physical templates (ANSI / Ortho / JIS / Custom) share standard ANSI
-        // touch-typing finger assignments, so ANSILayout() is the correct ergonomic model.
-        // When template is "Auto", check for an imported KLE JSON to detect Custom resolution
-        // (mirrors the effectiveTemplate logic in KeyboardHeatmapView).
-        let templateRaw = UserDefaults.standard.string(forKey: "heatmapTemplate") ?? "ANSI"
-        let hasKLE = !(UserDefaults.standard.string(forKey: "kleCustomLayoutJSON") ?? "").isEmpty
-        let userLayoutLabel: String = {
-            switch templateRaw {
-            case "Custom":                      return "Your Layout (Custom)"
-            case "Auto" where hasKLE:           return "Your Layout (Custom)"
-            case "Ortho":                       return "Your Layout (Ortho)"
-            case "JIS":                         return "Your Layout (JIS)"
-            default:                            return "Your Layout (ANSI)"
-            }
-        }()
-
-        func makeEntry(name: String, layout: any KeyboardLayout, isUserLayout: Bool = false) -> LayoutEfficiencyEntry {
-            let simRegistry = LayoutRegistry.forSimulation(layout: layout)
-            let snapshot    = ErgonomicSnapshot.capture(
-                bigramCounts: bigrams,
-                keyCounts:    keyCounts,
-                layout:       simRegistry
-            )
-            return LayoutEfficiencyEntry(
-                name:                name,
-                sameFingerRate:      snapshot.sameFingerRate,
-                handAlternationRate: snapshot.handAlternationRate,
-                ergonomicScore:      snapshot.ergonomicScore,
-                travelDistance:      snapshot.estimatedTravelDistance,
-                totalBigrams:        totalBigrams,
-                isUserLayout:        isUserLayout
-            )
-        }
-
-        let userEntry = makeEntry(name: userLayoutLabel, layout: ANSILayout(), isUserLayout: true)
-
-        let alternatives: [(name: String, layout: any KeyboardLayout)] = [
-            ("QWERTY",  ANSILayout()),
-            ("Colemak", ColemakLayout()),
-            ("Dvorak",  DvorakLayout()),
-        ]
-        let sorted = alternatives
-            .map { makeEntry(name: $0.name, layout: $0.layout) }
-            .sorted { $0.ergonomicScore > $1.ergonomicScore }
-
-        return [userEntry] + sorted
+        // Capture the snapshot inside the queue, then compute outside (expensive layout simulation).
+        let q = queue.sync { makeQuery() }
+        return q.layoutEfficiencyScores()
     }
 }
-

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -397,6 +397,22 @@ final class KeyCountStore {
 
     var todayKey: String { Self.dayFormatter.string(from: Date()) }
 
+    // MARK: - Query factory
+
+    /// Creates a read-only snapshot of the current store state for use with KeyMetricsQuery.
+    /// Must be called from inside queue.sync.
+    func makeQuery() -> KeyMetricsQuery {
+        KeyMetricsQuery(
+            store:               store,
+            pending:             pending,
+            dbQueue:             dbQueue,
+            recentIKIs:          recentIKIs,
+            rhythmIKIs:          rhythmIKIs,
+            todayKey:            todayKey,
+            wpmSessionStart:     wpmSessionStart
+        )
+    }
+
     // MARK: - Mutation
 
     /// Increment count by 1. Returns (newCount, isMilestone).

--- a/Sources/KeyLens/KeyMetricsQuery.swift
+++ b/Sources/KeyLens/KeyMetricsQuery.swift
@@ -1,0 +1,801 @@
+import Foundation
+import GRDB
+import KeyLensCore
+
+// MARK: - KeyMetricsQuery
+// Immutable snapshot of KeyCountStore data for read-only queries.
+// Always constructed inside KeyCountStore.queue.sync via KeyCountStore.makeQuery().
+// All methods operate on the captured snapshot — no locking needed.
+
+struct KeyMetricsQuery {
+    let store: CountData
+    let pending: PendingStore
+    let dbQueue: DatabaseQueue?
+    let recentIKIs: [(key: String, iki: Double)]
+    let rhythmIKIs: [Double]
+    let todayKey: String
+    let wpmSessionStart: Date?
+}
+
+// MARK: - Private helpers
+
+private extension KeyMetricsQuery {
+
+    func topEntries(_ dict: [String: Int], limit: Int) -> [(String, Int)] {
+        dict.sorted { $0.value > $1.value }
+            .prefix(limit)
+            .map { ($0.key, $0.value) }
+    }
+
+    func dailyKeyCounts(for date: String) -> [String: Int] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT key, count FROM daily_keys WHERE date = ?", arguments: [date])
+           }) {
+            for row in rows { result[row["key"], default: 0] += (row["count"] as Int) }
+        }
+        for (k, v) in pending.dailyKeys[date, default: [:]] { result[k, default: 0] += v }
+        return result
+    }
+
+    func dailyTotal(for date: String) -> Int {
+        var total = 0
+        if let db = dbQueue {
+            total = (try? db.read { db in
+                try Int.fetchOne(db, sql: "SELECT COALESCE(SUM(count),0) FROM daily_keys WHERE date = ?",
+                                 arguments: [date])
+            }) ?? 0
+        }
+        total += pending.dailyKeys[date, default: [:]].values.reduce(0, +)
+        return total
+    }
+
+    func allDates() -> [String] {
+        guard let db = dbQueue else { return [] }
+        return (try? db.read { db in
+            try String.fetchAll(db, sql: "SELECT DISTINCT date FROM daily_keys ORDER BY date")
+        }) ?? []
+    }
+
+    func mergedBigramIKI() -> [String: (sum: Double, count: Int)] {
+        var merged: [String: (sum: Double, count: Int)] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT bigram, iki_sum, iki_count FROM bigram_iki")
+           }) {
+            for row in rows {
+                let key: String = row["bigram"]
+                let sum: Double = row["iki_sum"]
+                let cnt: Int    = row["iki_count"]
+                merged[key] = (sum: sum, count: cnt)
+            }
+        }
+        for (bigram, p) in pending.bigramIKI {
+            let e = merged[bigram] ?? (sum: 0, count: 0)
+            merged[bigram] = (sum: e.sum + p.sum, count: e.count + p.count)
+        }
+        return merged
+    }
+}
+
+// MARK: - Activity queries
+
+extension KeyMetricsQuery {
+
+    func todayTopKeys(limit: Int = 10) -> [(key: String, count: Int)] {
+        topEntries(dailyKeyCounts(for: todayKey), limit: limit)
+    }
+
+    var todayCount: Int {
+        dailyTotal(for: todayKey)
+    }
+
+    func hourlyCounts(for date: String) -> [Int] {
+        var result = [Int](repeating: 0, count: 24)
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT hour, count FROM hourly_counts WHERE date = ?", arguments: [date])
+           }) {
+            for row in rows {
+                let h: Int = row["hour"]
+                if h < 24 { result[h] += (row["count"] as Int) }
+            }
+        }
+        for (h, v) in pending.hourly[date, default: [:]] where h < 24 { result[h] += v }
+        return result
+    }
+
+    func shortcutEfficiencyToday() -> Double? {
+        let shortcuts = store.shortcuts.dailyModifiedCount[todayKey] ?? 0
+        let dayCounts = dailyKeyCounts(for: todayKey)
+        let mouseClicks = dayCounts.filter { $0.key.hasPrefix("🖱") }.values.reduce(0, +)
+        let total = shortcuts + mouseClicks
+        guard total > 0 else { return nil }
+        return Double(shortcuts) / Double(total) * 100.0
+    }
+
+    func topModifiedKeys(prefix: String = "", limit: Int = 20) -> [(key: String, count: Int)] {
+        let filtered = prefix.isEmpty
+            ? store.shortcuts.modifiedCounts
+            : store.shortcuts.modifiedCounts.filter { $0.key.hasPrefix(prefix) }
+        return topEntries(filtered, limit: limit)
+    }
+
+    func topKeys(limit: Int = 10) -> [(key: String, count: Int)] {
+        topEntries(store.counts, limit: limit)
+    }
+
+    func topApps(limit: Int = 20) -> [(app: String, count: Int)] {
+        topEntries(store.appTracker.appCounts, limit: limit)
+    }
+
+    func topDevices(limit: Int = 20) -> [(device: String, count: Int)] {
+        topEntries(store.appTracker.deviceCounts, limit: limit)
+    }
+
+    func appErgonomicScores(minKeystrokes: Int = 100) -> [(app: String, score: Double, keystrokes: Int)] {
+        store.appTracker.appCounts
+            .filter { $0.value >= minKeystrokes }
+            .compactMap { (app, keystrokes) -> (app: String, score: Double, keystrokes: Int)? in
+                let bigrams = store.appTracker.appTotalBigramCount[app] ?? 0
+                guard bigrams > 0 else { return nil }
+                let score = KeyMetricsComputation.ergonomicScore(
+                    sfCount:     store.appTracker.appSameFingerCount[app]       ?? 0,
+                    hsCount:     store.appTracker.appHighStrainBigramCount[app] ?? 0,
+                    altCount:    store.appTracker.appHandAlternationCount[app]  ?? 0,
+                    bigramCount: bigrams
+                )
+                return (app: app, score: score, keystrokes: keystrokes)
+            }
+            .sorted { $0.score > $1.score }
+    }
+
+    func deviceErgonomicScores(minKeystrokes: Int = 100) -> [(device: String, score: Double, keystrokes: Int)] {
+        store.appTracker.deviceCounts
+            .filter { $0.value >= minKeystrokes }
+            .compactMap { (device, keystrokes) -> (device: String, score: Double, keystrokes: Int)? in
+                let bigrams = store.appTracker.deviceTotalBigramCount[device] ?? 0
+                guard bigrams > 0 else { return nil }
+                let score = KeyMetricsComputation.ergonomicScore(
+                    sfCount:     store.appTracker.deviceSameFingerCount[device]       ?? 0,
+                    hsCount:     store.appTracker.deviceHighStrainBigramCount[device] ?? 0,
+                    altCount:    store.appTracker.deviceHandAlternationCount[device]  ?? 0,
+                    bigramCount: bigrams
+                )
+                return (device: device, score: score, keystrokes: keystrokes)
+            }
+            .sorted { $0.score > $1.score }
+    }
+
+    func todayTopApps(limit: Int = 10) -> [(app: String, count: Int)] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT app, count FROM daily_apps WHERE date = ?", arguments: [todayKey])
+           }) {
+            for row in rows { result[row["app"], default: 0] += (row["count"] as Int) }
+        }
+        for (a, v) in pending.dailyApps[todayKey, default: [:]] { result[a, default: 0] += v }
+        return topEntries(result, limit: limit)
+    }
+
+    func todayTopDevices(limit: Int = 10) -> [(device: String, count: Int)] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT device, count FROM daily_devices WHERE date = ?", arguments: [todayKey])
+           }) {
+            for row in rows { result[row["device"], default: 0] += (row["count"] as Int) }
+        }
+        for (d, v) in pending.dailyDevices[todayKey, default: [:]] { result[d, default: 0] += v }
+        return topEntries(result, limit: limit)
+    }
+
+    var allBigramCounts: [String: Int] {
+        store.ergonomics.bigramCounts
+    }
+
+    var allKeyCounts: [String: Int] {
+        store.counts
+    }
+
+    func topBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
+        topEntries(store.ergonomics.bigramCounts, limit: limit)
+    }
+
+    func todayTopBigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT bigram, count FROM daily_bigrams WHERE date = ?", arguments: [todayKey])
+           }) {
+            for row in rows { result[row["bigram"], default: 0] += (row["count"] as Int) }
+        }
+        for (b, v) in pending.dailyBigrams[todayKey, default: [:]] { result[b, default: 0] += v }
+        return topEntries(result, limit: limit)
+    }
+
+    func topTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
+        topEntries(store.ergonomics.trigramCounts, limit: limit)
+    }
+
+    func todayTopTrigrams(limit: Int = 20) -> [(pair: String, count: Int)] {
+        var result: [String: Int] = [:]
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT trigram, count FROM daily_trigrams WHERE date = ?", arguments: [todayKey])
+           }) {
+            for row in rows { result[row["trigram"], default: 0] += (row["count"] as Int) }
+        }
+        for (t, v) in pending.dailyTrigrams[todayKey, default: [:]] { result[t, default: 0] += v }
+        return topEntries(result, limit: limit)
+    }
+
+    func avgBigramIKI(for bigram: String) -> Double? {
+        var sum: Double = 0
+        var count: Int  = 0
+        if let db = dbQueue,
+           let row = try? db.read({ db in
+               try Row.fetchOne(db, sql: "SELECT iki_sum, iki_count FROM bigram_iki WHERE bigram = ?", arguments: [bigram])
+           }) {
+            sum   = row["iki_sum"]   ?? 0
+            count = row["iki_count"] ?? 0
+        }
+        if let p = pending.bigramIKI[bigram] { sum += p.sum; count += p.count }
+        guard count > 0 else { return nil }
+        return sum / Double(count)
+    }
+
+    func rankedBigramsForTraining(minCount: Int = 5, topK: Int = 10) -> [BigramScore] {
+        let merged = mergedBigramIKI()
+        let candidates = merged.compactMap { bigram, data -> BigramScore? in
+            guard data.count > 0 else { return nil }
+            let meanIKI = data.sum / Double(data.count)
+            return BigramScore(bigram: bigram, meanIKI: meanIKI, count: data.count)
+        }
+        return BigramScore.topCandidates(candidates, minCount: minCount, topK: topK)
+    }
+
+    func rankedTrigramsForTraining(minCount: Int = 5, topK: Int = 10) -> [TrigramScore] {
+        let bigramMeanIKI: [String: Double] = mergedBigramIKI().compactMapValues { data -> Double? in
+            guard data.count > 0 else { return nil }
+            return data.sum / Double(data.count)
+        }
+
+        var counts: [String: Int] = store.ergonomics.trigramCounts
+        for (_, dayMap) in pending.dailyTrigrams {
+            for (t, v) in dayMap { counts[t, default: 0] += v }
+        }
+
+        let candidates: [TrigramScore] = counts.compactMap { trigram, count -> TrigramScore? in
+            guard let t = Trigram.parse(trigram),
+                  let ikiAB = bigramMeanIKI[t.leadingBigram],
+                  let ikiBC = bigramMeanIKI[t.trailingBigram]
+            else { return nil }
+            return TrigramScore(trigram: trigram, estimatedIKI: ikiAB + ikiBC, count: count)
+        }
+        return TrigramScore.topCandidates(candidates, minCount: minCount, topK: topK)
+    }
+
+    func allBigramIKI() -> [String: Double] {
+        mergedBigramIKI().compactMapValues { data -> Double? in
+            guard data.count > 0 else { return nil }
+            return data.sum / Double(data.count)
+        }
+    }
+
+    func ikiPerFinger() -> [(finger: String, avgIKI: Double)] {
+        let layout = ANSILayout()
+        var perFinger: [String: (sum: Double, count: Int)] = [:]
+        for (bigramKey, data) in mergedBigramIKI() where data.count > 0 {
+            guard let bigram = Bigram.parse(bigramKey),
+                  let finger = layout.finger(for: bigram.to) else { continue }
+            let e = perFinger[finger.rawValue] ?? (sum: 0, count: 0)
+            perFinger[finger.rawValue] = (sum: e.sum + data.sum, count: e.count + data.count)
+        }
+        return perFinger
+            .compactMap { finger, data -> (finger: String, avgIKI: Double)? in
+                guard data.count > 0 else { return nil }
+                return (finger: finger, avgIKI: data.sum / Double(data.count))
+            }
+            .sorted { $0.avgIKI > $1.avgIKI }
+    }
+
+    func slowestBigrams(minCount: Int = 5, limit: Int = 20) -> [(bigram: String, avgIKI: Double)] {
+        mergedBigramIKI()
+            .compactMap { bigram, data -> (bigram: String, avgIKI: Double)? in
+                guard data.count >= minCount else { return nil }
+                return (bigram: bigram, avgIKI: data.sum / Double(data.count))
+            }
+            .sorted { $0.avgIKI > $1.avgIKI }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    func keyTransitions(
+        for key: String,
+        minCount: Int = 3,
+        limit: Int = 15
+    ) -> (incoming: [(bigram: String, avgIKI: Double, count: Int)],
+          outgoing: [(bigram: String, avgIKI: Double, count: Int)]) {
+        let merged = mergedBigramIKI()
+
+        func toEntry(_ kv: (key: String, value: (sum: Double, count: Int)))
+            -> (bigram: String, avgIKI: Double, count: Int)? {
+            guard kv.value.count >= minCount else { return nil }
+            return (bigram: kv.key, avgIKI: kv.value.sum / Double(kv.value.count), count: kv.value.count)
+        }
+
+        let incoming = merged
+            .filter { $0.key.hasSuffix("→\(key)") }
+            .compactMap { toEntry($0) }
+            .sorted { $0.avgIKI > $1.avgIKI }
+            .prefix(limit).map { $0 }
+
+        let outgoing = merged
+            .filter { $0.key.hasPrefix("\(key)→") }
+            .compactMap { toEntry($0) }
+            .sorted { $0.avgIKI > $1.avgIKI }
+            .prefix(limit).map { $0 }
+
+        return (incoming: incoming, outgoing: outgoing)
+    }
+
+    func dailyTotals() -> [(date: String, total: Int)] {
+        guard let db = dbQueue else { return [] }
+        var map: [String: Int] = [:]
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: "SELECT date, SUM(count) as total FROM daily_keys GROUP BY date ORDER BY date")
+        }) {
+            for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
+        }
+        for (date, keys) in pending.dailyKeys { map[date, default: 0] += keys.values.reduce(0, +) }
+        return map.sorted { $0.key < $1.key }.map { (date: $0.key, total: $0.value) }
+    }
+
+    func dailyTotals(last days: Int) -> [(date: String, count: Int)] {
+        let cal = Calendar.current
+        let cutoffDate = cal.date(byAdding: .day, value: -(days - 1), to: Date()) ?? Date()
+        guard let db = dbQueue else { return [] }
+        let cutoff = KeyCountStore.dayFormatter.string(from: cutoffDate)
+        var map: [String: Int] = [:]
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: """
+                SELECT date, SUM(count) as total FROM daily_keys WHERE date >= ? GROUP BY date
+                """, arguments: [cutoff])
+        }) {
+            for row in rows { map[row["date"], default: 0] = (row["total"] as Int) }
+        }
+        for (date, keys) in pending.dailyKeys where date >= cutoff {
+            map[date, default: 0] += keys.values.reduce(0, +)
+        }
+        return (0..<days).reversed().compactMap { offset -> (String, Int)? in
+            guard let date = cal.date(byAdding: .day, value: -offset, to: Date()) else { return nil }
+            let key = KeyCountStore.dayFormatter.string(from: date)
+            return (key, map[key] ?? 0)
+        }
+    }
+
+    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double)] {
+        var sums = [Int: [Int: Int]]()
+        var days = [Int: Set<String>]()
+
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: """
+                   SELECT date,
+                          CAST(strftime('%w', date) AS INTEGER) AS weekday,
+                          hour,
+                          count
+                   FROM hourly_counts
+                   """)
+           }) {
+            for row in rows {
+                let date: String = row["date"]
+                let wd: Int      = row["weekday"]
+                let h: Int       = row["hour"]
+                let c: Int       = row["count"]
+                guard h < 24 else { continue }
+                sums[wd, default: [:]][h, default: 0] += c
+                days[wd, default: []].insert(date)
+            }
+        }
+
+        let cal = Calendar.current
+        for (date, hours) in pending.hourly {
+            guard let d = KeyCountStore.dayFormatter.date(from: date) else { continue }
+            let wd = cal.component(.weekday, from: d) - 1
+            days[wd, default: []].insert(date)
+            for (h, v) in hours where h < 24 {
+                sums[wd, default: [:]][h, default: 0] += v
+            }
+        }
+
+        var result: [(weekday: Int, hour: Int, avgCount: Double)] = []
+        for wd in 0..<7 {
+            let dayCount = days[wd]?.count ?? 0
+            for h in 0..<24 {
+                let sum = sums[wd]?[h] ?? 0
+                let avg = dayCount > 0 ? Double(sum) / Double(dayCount) : 0.0
+                result.append((weekday: wd, hour: h, avgCount: avg))
+            }
+        }
+        return result
+    }
+
+    func hourlyDistribution() -> [Int] {
+        var result = [Int](repeating: 0, count: 24)
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db, sql: "SELECT hour, SUM(count) as total FROM hourly_counts GROUP BY hour")
+           }) {
+            for row in rows {
+                let h: Int = row["hour"]
+                if h < 24 { result[h] += (row["total"] as Int) }
+            }
+        }
+        for (_, hours) in pending.hourly { for (h, v) in hours where h < 24 { result[h] += v } }
+        return result
+    }
+
+    func monthlyTotals() -> [(month: String, total: Int)] {
+        guard let db = dbQueue else { return [] }
+        var map: [String: Int] = [:]
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: """
+                SELECT SUBSTR(date,1,7) as month, SUM(count) as total
+                FROM daily_keys GROUP BY month ORDER BY month
+                """)
+        }) {
+            for row in rows { map[row["month"], default: 0] = (row["total"] as Int) }
+        }
+        for (date, keys) in pending.dailyKeys {
+            guard date.count >= 7 else { continue }
+            map[String(date.prefix(7)), default: 0] += keys.values.reduce(0, +)
+        }
+        return map.sorted { $0.key < $1.key }.map { (month: $0.key, total: $0.value) }
+    }
+
+    func countsByType() -> [(type: KeyType, count: Int)] {
+        var totals: [KeyType: Int] = [:]
+        for (key, count) in store.counts {
+            totals[KeyType.classify(key), default: 0] += count
+        }
+        return KeyType.allCases
+            .compactMap { t in totals[t].map { (type: t, count: $0) } }
+            .filter { $0.count > 0 }
+            .sorted { $0.count > $1.count }
+    }
+
+    func topKeysPerDay(limit: Int = 10, recentDays: Int = 14) -> [(date: String, key: String, count: Int)] {
+        guard let db = dbQueue else { return [] }
+        let cal = Calendar.current
+        let cutoffDate = cal.date(byAdding: .day, value: -recentDays, to: Date()) ?? Date()
+        let cutoff = KeyCountStore.dayFormatter.string(from: cutoffDate)
+
+        var dateMap: [String: [String: Int]] = [:]
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: "SELECT date, key, count FROM daily_keys WHERE date >= ? ORDER BY date",
+                             arguments: [cutoff])
+        }) {
+            for row in rows {
+                dateMap[row["date"], default: [:]][row["key"], default: 0] += (row["count"] as Int)
+            }
+        }
+        for (date, keys) in pending.dailyKeys where date >= cutoff {
+            for (k, v) in keys { dateMap[date, default: [:]][k, default: 0] += v }
+        }
+
+        var combined: [String: Int] = [:]
+        for (_, keys) in dateMap { for (k, v) in keys { combined[k, default: 0] += v } }
+        let topKeyNames = topEntries(combined, limit: limit).map { $0.0 }
+
+        let dates = Array(dateMap.keys.sorted().suffix(recentDays))
+        var result: [(date: String, key: String, count: Int)] = []
+        for date in dates {
+            let dayCounts = dateMap[date] ?? [:]
+            for key in topKeyNames {
+                result.append((date: date, key: key, count: dayCounts[key] ?? 0))
+            }
+        }
+        return result
+    }
+
+    func latestIKIs() -> [(key: String, iki: Double)] { recentIKIs }
+
+    var isWPMMeasuring: Bool { wpmSessionStart != nil }
+
+    func allEntries() -> [(key: String, total: Int, today: Int)] {
+        let todayData = dailyKeyCounts(for: todayKey)
+        return store.counts.sorted { $0.value > $1.value }
+            .map { (key: $0.key, total: $0.value, today: todayData[$0.key] ?? 0) }
+    }
+}
+
+// MARK: - Ergonomic queries
+
+extension KeyMetricsQuery {
+
+    var averageIntervalMs: Double? {
+        store.activity.avgIntervalCount > 0 ? store.activity.avgIntervalMs : nil
+    }
+
+    var estimatedWPM: Double? {
+        guard let ms = averageIntervalMs, ms > 0 else { return nil }
+        return KeyMetricsComputation.wpm(avgIntervalMs: ms)
+    }
+
+    func rollingWPM(windowSeconds: Double = 5.0) -> Double {
+        guard let last = store.activity.lastInputTime,
+              Date().timeIntervalSince(last) <= AppConfiguration.wpmIdleDecaySecs else { return 0.0 }
+        let windowMs = windowSeconds * 1000.0
+        var totalMs = 0.0
+        var count = 0
+        for entry in recentIKIs.reversed() {
+            guard entry.iki > 0 else { continue }
+            guard totalMs + entry.iki <= windowMs else { break }
+            totalMs += entry.iki
+            count += 1
+        }
+        guard count > 0, totalMs > 0 else { return 0.0 }
+        return KeyMetricsComputation.wpm(avgIntervalMs: totalMs / Double(count))
+    }
+
+    var backspaceRate: Double? {
+        let total = store.counts.values.reduce(0, +)
+        guard total > 0 else { return nil }
+        return Double(store.counts["Delete", default: 0]) / Double(total) * 100.0
+    }
+
+    var todayBackspaceRate: Double? {
+        let dayCounts = dailyKeyCounts(for: todayKey)
+        let total = dayCounts.values.reduce(0, +)
+        guard total > 0 else { return nil }
+        return Double(dayCounts["Delete", default: 0]) / Double(total) * 100.0
+    }
+
+    func dailyBackspaceRates() -> [(date: String, rate: Double)] {
+        guard let db = dbQueue else { return [] }
+        var result: [(date: String, rate: Double)] = []
+        if let rows = try? db.read({ db in
+            try Row.fetchAll(db, sql: """
+                SELECT date,
+                       SUM(count) as total,
+                       SUM(CASE WHEN key = 'Delete' THEN count ELSE 0 END) as deletes
+                FROM daily_keys WHERE date < ?
+                GROUP BY date HAVING total > 0 ORDER BY date
+                """, arguments: [todayKey])
+        }) {
+            for row in rows {
+                let total: Int = row["total"]
+                guard total > 0 else { continue }
+                result.append((row["date"], Double(row["deletes"] as Int) / Double(total) * 100.0))
+            }
+        }
+        let todayCounts = dailyKeyCounts(for: todayKey)
+        let todayTotal  = todayCounts.values.reduce(0, +)
+        if todayTotal > 0 {
+            result.append((todayKey, Double(todayCounts["Delete", default: 0]) / Double(todayTotal) * 100.0))
+        }
+        return result
+    }
+
+    func dailyWPM() -> [(date: String, wpm: Double)] {
+        store.activity.dailyAvgIntervalMs.compactMap { date, avgMs -> (date: String, wpm: Double)? in
+            guard let count = store.activity.dailyAvgIntervalCount[date], count > 0, avgMs > 0 else { return nil }
+            return (date, KeyMetricsComputation.wpm(avgIntervalMs: avgMs))
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    var todayMinIntervalMs: Double? {
+        store.activity.dailyMinIntervalMs[todayKey]
+    }
+
+    var sameFingerRate: Double? {
+        guard store.ergonomics.totalBigramCount > 0 else { return nil }
+        return Double(store.ergonomics.sameFingerCount) / Double(store.ergonomics.totalBigramCount)
+    }
+
+    var todaySameFingerRate: Double? {
+        let total = store.ergonomics.dailyTotalBigramCount[todayKey] ?? 0
+        guard total > 0 else { return nil }
+        return Double(store.ergonomics.dailySameFingerCount[todayKey] ?? 0) / Double(total)
+    }
+
+    var handAlternationRate: Double? {
+        guard store.ergonomics.totalBigramCount > 0 else { return nil }
+        return Double(store.ergonomics.handAlternationCount) / Double(store.ergonomics.totalBigramCount)
+    }
+
+    var todayHandAlternationRate: Double? {
+        let total = store.ergonomics.dailyTotalBigramCount[todayKey] ?? 0
+        guard total > 0 else { return nil }
+        return Double(store.ergonomics.dailyHandAlternationCount[todayKey] ?? 0) / Double(total)
+    }
+
+    var alternationRewardScore: Double {
+        store.ergonomics.alternationRewardScore
+    }
+
+    var thumbImbalanceRatio: Double? {
+        LayoutRegistry.shared.thumbImbalanceDetector
+            .imbalanceRatio(counts: store.counts, layout: LayoutRegistry.shared)
+    }
+
+    func dailyThumbImbalance(for date: String) -> Double? {
+        let dayCounts = dailyKeyCounts(for: date)
+        guard !dayCounts.isEmpty else { return nil }
+        return LayoutRegistry.shared.thumbImbalanceDetector
+            .imbalanceRatio(counts: dayCounts, layout: LayoutRegistry.shared)
+    }
+
+    func dailyErgonomicRates() -> [(date: String, sameFingerRate: Double, handAltRate: Double, highStrainRate: Double)] {
+        allDates().compactMap { date in
+            let bigrams = store.ergonomics.dailyTotalBigramCount[date] ?? 0
+            guard bigrams > 0 else { return nil }
+            let sf = Double(store.ergonomics.dailySameFingerCount[date]       ?? 0) / Double(bigrams)
+            let ha = Double(store.ergonomics.dailyHandAlternationCount[date]  ?? 0) / Double(bigrams)
+            let hs = Double(store.ergonomics.dailyHighStrainBigramCount[date] ?? 0) / Double(bigrams)
+            return (date: date, sameFingerRate: sf, handAltRate: ha, highStrainRate: hs)
+        }
+    }
+
+    var highStrainBigramCount: Int {
+        store.ergonomics.highStrainBigramCount
+    }
+
+    var highStrainBigramRate: Double? {
+        guard store.ergonomics.totalBigramCount > 0 else { return nil }
+        return Double(store.ergonomics.highStrainBigramCount) / Double(store.ergonomics.totalBigramCount)
+    }
+
+    var highStrainTrigramCount: Int {
+        store.ergonomics.highStrainTrigramCount
+    }
+
+    func topHighStrainBigrams(limit: Int = 10) -> [(pair: String, count: Int)] {
+        let detector = LayoutRegistry.shared.highStrainDetector
+        let layout   = LayoutRegistry.shared
+        return store.ergonomics.bigramCounts
+            .filter { pair, _ in
+                guard let b = Bigram.parse(pair) else { return false }
+                return detector.isHighStrain(from: b.from, to: b.to, layout: layout)
+            }
+            .sorted { $0.value > $1.value }
+            .prefix(limit)
+            .map { (pair: $0.key, count: $0.value) }
+    }
+
+    var thumbEfficiencyCoefficient: Double? {
+        LayoutRegistry.shared.thumbEfficiencyCalculator
+            .coefficient(counts: store.counts, layout: LayoutRegistry.shared)
+    }
+
+    var currentErgonomicScore: Double {
+        KeyMetricsComputation.ergonomicScore(
+            sfCount:      store.ergonomics.sameFingerCount,
+            hsCount:      store.ergonomics.highStrainBigramCount,
+            altCount:     store.ergonomics.handAlternationCount,
+            bigramCount:  store.ergonomics.totalBigramCount,
+            keyCounts:    store.counts
+        )
+    }
+
+    var currentTypingStyle: TypingStyle {
+        TypingStyleAnalyzer().analyze(keyCounts: store.counts)
+    }
+
+    var currentTypingRhythm: TypingRhythm {
+        TypingRhythmAnalyzer().analyze(ikis: rhythmIKIs)
+    }
+
+    var currentFatigueLevel: FatigueLevel {
+        let bigrams = store.ergonomics.totalBigramCount
+        let hsRate = bigrams > 0 ? Double(store.ergonomics.highStrainBigramCount) / Double(bigrams) : 0.0
+        return FatigueRiskModel().analyze(
+            currentAvgIntervalMs:   nil,
+            baselineAvgIntervalMs:  nil,
+            currentHighStrainRate:  hsRate,
+            baselineHighStrainRate: 0.02
+        )
+    }
+
+    func todayHourlyFatigueCurve() -> [HourlyFatigueEntry] {
+        var slices: [Int: (ikiSum: Double, ikiCount: Int, ergTotal: Int, ergSF: Int, ergHS: Int)] = [:]
+
+        if let db = dbQueue,
+           let rows = try? db.read({ db in
+               try Row.fetchAll(db,
+                   sql: "SELECT hour, iki_sum, iki_count, erg_total, erg_sf, erg_hs FROM hourly_ergonomics WHERE date = ?",
+                   arguments: [todayKey])
+           }) {
+            for row in rows {
+                let h: Int = row["hour"]
+                slices[h] = (row["iki_sum"], row["iki_count"], row["erg_total"], row["erg_sf"], row["erg_hs"])
+            }
+        }
+
+        for (h, sl) in pending.hourlySlices[todayKey, default: [:]] {
+            let e = slices[h] ?? (0, 0, 0, 0, 0)
+            slices[h] = (e.ikiSum   + sl.ikiSum,   e.ikiCount + sl.ikiCount,
+                         e.ergTotal + sl.ergTotal, e.ergSF    + sl.ergSF,
+                         e.ergHS    + sl.ergHS)
+        }
+
+        return slices.compactMap { hour, s -> HourlyFatigueEntry? in
+            guard s.ikiCount > 0 || s.ergTotal > 0 else { return nil }
+            let wpm: Double? = s.ikiCount > 0
+                ? KeyMetricsComputation.wpm(avgIntervalMs: s.ikiSum / Double(s.ikiCount))
+                : nil
+            let sfRate: Double? = s.ergTotal > 0 ? Double(s.ergSF) / Double(s.ergTotal) : nil
+            let hsRate: Double? = s.ergTotal > 0 ? Double(s.ergHS) / Double(s.ergTotal) : nil
+            return HourlyFatigueEntry(id: hour, hour: hour, wpm: wpm, sameFingerRate: sfRate, highStrainRate: hsRate)
+        }
+        .sorted { $0.hour < $1.hour }
+    }
+
+    var dailyErgonomicScore: [String: Double] {
+        var result: [String: Double] = [:]
+        for date in allDates() {
+            let bigrams = store.ergonomics.dailyTotalBigramCount[date] ?? 0
+            guard bigrams > 0 else { continue }
+            result[date] = KeyMetricsComputation.ergonomicScore(
+                sfCount:     store.ergonomics.dailySameFingerCount[date]       ?? 0,
+                hsCount:     store.ergonomics.dailyHighStrainBigramCount[date] ?? 0,
+                altCount:    store.ergonomics.dailyHandAlternationCount[date]  ?? 0,
+                bigramCount: bigrams,
+                keyCounts:   dailyKeyCounts(for: date)
+            )
+        }
+        return result
+    }
+
+    func layoutEfficiencyScores() -> [LayoutEfficiencyEntry] {
+        let bigrams   = store.ergonomics.bigramCounts
+        let keyCounts = store.counts
+        guard !bigrams.isEmpty else { return [] }
+        let totalBigrams = bigrams.values.reduce(0, +)
+
+        let templateRaw = UserDefaults.standard.string(forKey: "heatmapTemplate") ?? "ANSI"
+        let hasKLE = !(UserDefaults.standard.string(forKey: "kleCustomLayoutJSON") ?? "").isEmpty
+        let userLayoutLabel: String = {
+            switch templateRaw {
+            case "Custom":              return "Your Layout (Custom)"
+            case "Auto" where hasKLE:   return "Your Layout (Custom)"
+            case "Ortho":               return "Your Layout (Ortho)"
+            case "JIS":                 return "Your Layout (JIS)"
+            default:                    return "Your Layout (ANSI)"
+            }
+        }()
+
+        func makeEntry(name: String, layout: any KeyboardLayout, isUserLayout: Bool = false) -> LayoutEfficiencyEntry {
+            let simRegistry = LayoutRegistry.forSimulation(layout: layout)
+            let snapshot    = ErgonomicSnapshot.capture(
+                bigramCounts: bigrams,
+                keyCounts:    keyCounts,
+                layout:       simRegistry
+            )
+            return LayoutEfficiencyEntry(
+                name:                name,
+                sameFingerRate:      snapshot.sameFingerRate,
+                handAlternationRate: snapshot.handAlternationRate,
+                ergonomicScore:      snapshot.ergonomicScore,
+                travelDistance:      snapshot.estimatedTravelDistance,
+                totalBigrams:        totalBigrams,
+                isUserLayout:        isUserLayout
+            )
+        }
+
+        let userEntry = makeEntry(name: userLayoutLabel, layout: ANSILayout(), isUserLayout: true)
+
+        let sorted = [("QWERTY", ANSILayout() as any KeyboardLayout),
+                      ("Colemak", ColemakLayout()),
+                      ("Dvorak", DvorakLayout())]
+            .map { makeEntry(name: $0.0, layout: $0.1) }
+            .sorted { $0.ergonomicScore > $1.ergonomicScore }
+
+        return [userEntry] + sorted
+    }
+}


### PR DESCRIPTION
## Summary

- New `KeyMetricsQuery.swift`: immutable snapshot struct capturing `CountData`, `PendingStore`, `DatabaseQueue?`, ring buffers, and `todayKey` at query time
- All read-only methods from `KeyCountStore+Activity.swift` and `KeyCountStore+Ergonomics.swift` moved to `KeyMetricsQuery` — no locking needed, methods operate on the snapshot
- `KeyCountStore` gains `makeQuery()` factory (called inside `queue.sync`); extension methods become one-liner wrappers
- No user-visible behaviour change; no schema change; no L10n change

## Testability gain

`KeyMetricsQuery` can be instantiated with mock data directly — no `KeyCountStore` singleton needed:
```swift
let q = KeyMetricsQuery(store: mockData, pending: PendingStore(), dbQueue: nil,
                        recentIKIs: [], rhythmIKIs: [], todayKey: "2026-03-24", wpmSessionStart: nil)
XCTAssertNil(q.averageIntervalMs)
```

## Scope

Phase 3a of #215. `KeyMetricsStore` (SQLite/flush extraction) deferred to a future phase.

## Test plan
- [ ] Build passes (`swift build -c release`) ✅
- [ ] Run app and verify all tabs display correctly
- [ ] Confirm no regression in keystroke counting or ergonomic metrics