### PR TITLE
feat: interactive 2D heatmap — Day of Week × Hour of Day (#239)

### DIFF
--- a/Sources/KeyLens/Charts+ActivityTab.swift
+++ b/Sources/KeyLens/Charts+ActivityTab.swift
@@ -397,67 +397,85 @@ extension ChartsView {
     }
 }
 
-// MARK: - Issue #78: WeeklyHeatmapView
+// MARK: - Issue #239: WeeklyHeatmapView (GitHub-contribution style, 7 rows × 24 cols)
 
-/// A 7-column × 24-row grid showing average keystrokes per (day-of-week, hour) cell.
-/// Color intensity scales linearly from the cell's avgCount to the maximum across all cells.
-/// Hovering over a cell shows a tooltip below the grid.
+/// Interactive 7-row (Mon–Sun) × 24-column (0–23h) heatmap.
+/// Supports a metric toggle: Keystrokes / WPM.
+/// Hovering over a cell shows a tooltip with count + WPM.
 struct WeeklyHeatmapView: View {
     let cells: [HeatmapCell]
 
     @State private var hoveredCell: HeatmapCell? = nil
+    @State private var metric: HeatmapMetric = .keystrokes
 
-    private let cellW:   CGFloat = 26
-    private let cellH:   CGFloat = 10
-    private let labelW:  CGFloat = 28
-    private let headerH: CGFloat = 22
+    enum HeatmapMetric { case keystrokes, wpm }
 
-    // Pre-build lookup [weekday * 24 + hour → cell] for O(1) access.
+    private let cellW:   CGFloat = 22
+    private let cellH:   CGFloat = 18
+    private let labelW:  CGFloat = 30
+    private let headerH: CGFloat = 20
+
     private var lookup: [Int: HeatmapCell] {
         Dictionary(uniqueKeysWithValues: cells.map { ($0.weekday * 24 + $0.hour, $0) })
     }
 
-    private var maxAvg: Double {
-        cells.map(\.avgCount).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+    private var maxValue: Double {
+        switch metric {
+        case .keystrokes:
+            return cells.map(\.avgCount).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+        case .wpm:
+            return cells.compactMap(\.avgWPM).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+        }
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 8) {
+            // Metric toggle
+            Picker("", selection: $metric) {
+                Text(L10n.shared.heatmapMetricKeys).tag(HeatmapMetric.keystrokes)
+                Text(L10n.shared.heatmapMetricWPM).tag(HeatmapMetric.wpm)
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 200)
+
             grid
             tooltipLine
+            legend
         }
     }
 
+    // 7 rows (weekday) × 24 columns (hour)
     private var grid: some View {
-        HStack(alignment: .top, spacing: 0) {
-            hourLabels
-            ForEach(0..<7, id: \.self) { wd in
-                dayColumn(wd: wd)
+        VStack(alignment: .leading, spacing: 0) {
+            // Hour header row
+            HStack(spacing: 0) {
+                Spacer().frame(width: labelW)
+                ForEach(0..<24, id: \.self) { h in
+                    Text(h % 4 == 0 ? String(format: "%02d", h) : "")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.secondary)
+                        .frame(width: cellW, height: headerH, alignment: .leading)
+                }
+            }
+            // One row per weekday (Sun=0 … Sat=6), reordered to Mon-first display
+            ForEach(weekdayDisplayOrder, id: \.self) { wd in
+                weekdayRow(wd: wd)
             }
         }
     }
 
-    private var hourLabels: some View {
-        VStack(spacing: 0) {
-            Spacer().frame(height: headerH)
-            ForEach(0..<24, id: \.self) { h in
-                Text(h % 3 == 0 ? String(format: "%02d", h) : "")
-                    .font(.system(size: 8))
-                    .foregroundStyle(.secondary)
-                    .frame(width: labelW, height: cellH, alignment: .trailing)
-                    .padding(.trailing, 3)
-            }
-        }
-    }
+    // Display Mon(1)…Sat(6), Sun(0) — Monday first
+    private var weekdayDisplayOrder: [Int] { [1, 2, 3, 4, 5, 6, 0] }
 
-    private func dayColumn(wd: Int) -> some View {
+    private func weekdayRow(wd: Int) -> some View {
         let abbrs = L10n.shared.weekdayAbbrs
         let label = wd < abbrs.count ? abbrs[wd] : ""
-        return VStack(spacing: 0) {
+        return HStack(spacing: 0) {
             Text(label)
                 .font(.system(size: 9, weight: .medium))
                 .foregroundStyle(.secondary)
-                .frame(width: cellW, height: headerH)
+                .frame(width: labelW, height: cellH, alignment: .trailing)
+                .padding(.trailing, 4)
             ForEach(0..<24, id: \.self) { h in
                 cellView(wd: wd, hour: h)
             }
@@ -465,18 +483,20 @@ struct WeeklyHeatmapView: View {
     }
 
     private func cellView(wd: Int, hour: Int) -> some View {
-        let cell = lookup[wd * 24 + hour]
-        let avg  = cell?.avgCount ?? 0
-        let intensity = maxAvg > 0 ? avg / maxAvg : 0
-        // Minimum opacity 0.06 so empty cells remain visible as outlines.
+        let cell  = lookup[wd * 24 + hour]
+        let value: Double = {
+            switch metric {
+            case .keystrokes: return cell?.avgCount ?? 0
+            case .wpm:        return cell?.avgWPM   ?? 0
+            }
+        }()
+        let intensity = maxValue > 0 ? min(value / maxValue, 1.0) : 0
         let fill = Color.blue.opacity(0.06 + intensity * 0.88)
         return Rectangle()
             .fill(fill)
             .frame(width: cellW - 1, height: cellH - 1)
-            .cornerRadius(1)
-            .onHover { hovering in
-                hoveredCell = hovering ? cell : nil
-            }
+            .cornerRadius(2)
+            .onHover { hovering in hoveredCell = hovering ? cell : nil }
     }
 
     @ViewBuilder
@@ -485,12 +505,35 @@ struct WeeklyHeatmapView: View {
             let fullNames = L10n.shared.weekdayFullNames
             let dayName   = cell.weekday < fullNames.count ? fullNames[cell.weekday] : ""
             let hourStr   = String(format: "%02d:00", cell.hour)
-            let avgLabel  = L10n.shared.heatmapAvgLabel(Int(cell.avgCount.rounded()))
-            Text("\(dayName) \(hourStr)  ·  \(avgLabel)")
+            let keysLabel = L10n.shared.heatmapAvgLabel(Int(cell.avgCount.rounded()))
+            let wpmPart: String = {
+                if let wpm = cell.avgWPM {
+                    return "  ·  \(String(format: "%.0f", wpm)) WPM"
+                }
+                return ""
+            }()
+            Text("\(dayName) \(hourStr)  ·  \(keysLabel)\(wpmPart)")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         } else {
-            Text(" ").font(.caption)  // fixed-height placeholder keeps layout stable
+            Text(" ").font(.caption)
+        }
+    }
+
+    private var legend: some View {
+        HStack(spacing: 4) {
+            Text(L10n.shared.calendarLegendLow)
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
+            ForEach([0.1, 0.3, 0.5, 0.7, 1.0], id: \.self) { i in
+                Rectangle()
+                    .fill(Color.blue.opacity(0.06 + i * 0.88))
+                    .frame(width: 10, height: 10)
+                    .cornerRadius(2)
+            }
+            Text(L10n.shared.calendarLegendHigh)
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -275,18 +275,20 @@ struct MouseKeyboardBalanceEntry: Identifiable {
 
 // MARK: - Issue #78: Weekly Activity Heatmap
 
-/// One cell in the 7×24 weekly heatmap: average keystrokes for a given (weekday, hour) pair.
-/// 週間ヒートマップの1セル：曜日×時刻ごとの平均打鍵数。
+/// One cell in the 7×24 weekly heatmap: average keystrokes and optional WPM for a (weekday, hour) pair.
+/// 週間ヒートマップの1セル：曜日×時刻ごとの平均打鍵数・平均WPM。
 struct HeatmapCell: Identifiable {
     let id: Int           // weekday * 24 + hour
     let weekday: Int      // 0 = Sunday … 6 = Saturday
     let hour: Int         // 0–23
     let avgCount: Double  // average keystrokes across all matching dates
-    init(_ t: (weekday: Int, hour: Int, avgCount: Double)) {
-        id = t.weekday * 24 + t.hour
+    let avgWPM: Double?   // average WPM for this cell, nil if no IKI data
+    init(_ t: (weekday: Int, hour: Int, avgCount: Double, avgWPM: Double?)) {
+        id       = t.weekday * 24 + t.hour
         weekday  = t.weekday
         hour     = t.hour
         avgCount = t.avgCount
+        avgWPM   = t.avgWPM
     }
 }
 

--- a/Sources/KeyLens/KeyCountStore+Activity.swift
+++ b/Sources/KeyLens/KeyCountStore+Activity.swift
@@ -120,7 +120,7 @@ extension KeyCountStore {
         queue.sync { makeQuery().dailyTotals(last: days) }
     }
 
-    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double)] {
+    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double, avgWPM: Double?)] {
         queue.sync { makeQuery().hourlyCountsByDayOfWeek() }
     }
 

--- a/Sources/KeyLens/KeyMetricsQuery.swift
+++ b/Sources/KeyLens/KeyMetricsQuery.swift
@@ -377,28 +377,53 @@ extension KeyMetricsQuery {
         }
     }
 
-    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double)] {
+    func hourlyCountsByDayOfWeek() -> [(weekday: Int, hour: Int, avgCount: Double, avgWPM: Double?)] {
         var sums = [Int: [Int: Int]]()
         var days = [Int: Set<String>]()
+        // iki_sum / iki_count per (weekday, hour) for WPM computation
+        var ikiSums   = [Int: [Int: Double]]()
+        var ikiCounts = [Int: [Int: Int]]()
 
-        if let db = dbQueue,
-           let rows = try? db.read({ db in
-               try Row.fetchAll(db, sql: """
-                   SELECT date,
-                          CAST(strftime('%w', date) AS INTEGER) AS weekday,
-                          hour,
-                          count
-                   FROM hourly_counts
-                   """)
-           }) {
-            for row in rows {
-                let date: String = row["date"]
-                let wd: Int      = row["weekday"]
-                let h: Int       = row["hour"]
-                let c: Int       = row["count"]
-                guard h < 24 else { continue }
-                sums[wd, default: [:]][h, default: 0] += c
-                days[wd, default: []].insert(date)
+        if let db = dbQueue {
+            // Keystroke counts
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date,
+                           CAST(strftime('%w', date) AS INTEGER) AS weekday,
+                           hour,
+                           count
+                    FROM hourly_counts
+                    """)
+            }) {
+                for row in rows {
+                    let date: String = row["date"]
+                    let wd: Int      = row["weekday"]
+                    let h: Int       = row["hour"]
+                    let c: Int       = row["count"]
+                    guard h < 24 else { continue }
+                    sums[wd, default: [:]][h, default: 0] += c
+                    days[wd, default: []].insert(date)
+                }
+            }
+            // WPM data from hourly_ergonomics
+            if let rows = try? db.read({ db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date,
+                           CAST(strftime('%w', date) AS INTEGER) AS weekday,
+                           hour, iki_sum, iki_count
+                    FROM hourly_ergonomics
+                    WHERE iki_count > 0
+                    """)
+            }) {
+                for row in rows {
+                    let wd: Int      = row["weekday"]
+                    let h: Int       = row["hour"]
+                    let s: Double    = row["iki_sum"]
+                    let n: Int       = row["iki_count"]
+                    guard h < 24 else { continue }
+                    ikiSums[wd, default: [:]][h, default: 0.0] += s
+                    ikiCounts[wd, default: [:]][h, default: 0] += n
+                }
             }
         }
 
@@ -411,14 +436,28 @@ extension KeyMetricsQuery {
                 sums[wd, default: [:]][h, default: 0] += v
             }
         }
+        // Merge pending hourly IKI slices
+        for (date, slices) in pending.hourlySlices {
+            guard let d = KeyCountStore.dayFormatter.date(from: date) else { continue }
+            let wd = cal.component(.weekday, from: d) - 1
+            for (h, sl) in slices where h < 24 && sl.ikiCount > 0 {
+                ikiSums[wd, default: [:]][h, default: 0.0]  += sl.ikiSum
+                ikiCounts[wd, default: [:]][h, default: 0]  += sl.ikiCount
+            }
+        }
 
-        var result: [(weekday: Int, hour: Int, avgCount: Double)] = []
+        var result: [(weekday: Int, hour: Int, avgCount: Double, avgWPM: Double?)] = []
         for wd in 0..<7 {
             let dayCount = days[wd]?.count ?? 0
             for h in 0..<24 {
-                let sum = sums[wd]?[h] ?? 0
-                let avg = dayCount > 0 ? Double(sum) / Double(dayCount) : 0.0
-                result.append((weekday: wd, hour: h, avgCount: avg))
+                let sum    = sums[wd]?[h] ?? 0
+                let avg    = dayCount > 0 ? Double(sum) / Double(dayCount) : 0.0
+                let ikiSum = ikiSums[wd]?[h] ?? 0
+                let ikiN   = ikiCounts[wd]?[h] ?? 0
+                let wpm: Double? = ikiN > 0
+                    ? KeyMetricsComputation.wpm(avgIntervalMs: ikiSum / Double(ikiN))
+                    : nil
+                result.append((weekday: wd, hour: h, avgCount: avg, avgWPM: wpm))
             }
         }
         return result

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1534,6 +1534,26 @@ final class L10n {
         ja("平均 \(count) キー", en: "avg \(count) keys")
     }
 
+    var heatmapMetricKeys: String {
+        ja("打鍵数", en: "Keystrokes")
+    }
+
+    var heatmapMetricWPM: String {
+        ja("WPM", en: "WPM")
+    }
+
+    var heatmapNoWPMData: String {
+        ja("—", en: "—")
+    }
+
+    var calendarLegendLow: String {
+        ja("少", en: "Low")
+    }
+
+    var calendarLegendHigh: String {
+        ja("多", en: "High")
+    }
+
     // MARK: - Issue #60: Session detection
 
     var chartTitleSessions: String {


### PR DESCRIPTION
## Summary

- **Orientation flipped** to GitHub-contribution style: 7 rows (Mon–Sun) × 24 columns (0–23h)
- **Metric toggle**: Keystrokes / WPM (segmented picker above the grid)
- **WPM data**: `hourlyCountsByDayOfWeek()` now also reads `hourly_ergonomics` for per-cell average WPM
- **HeatmapCell** extended with `avgWPM: Double?`
- **Tooltip**: shows day + hour + avg keystrokes + WPM (if available)
- **Legend**: Low → High color scale at bottom

## Test plan

- [ ] Open Charts → Activity tab → Weekly Activity Heatmap
- [ ] Confirm grid shows 7 rows × 24 columns (Monday first)
- [ ] Toggle to WPM — cells change intensity based on WPM
- [ ] Hover a cell — tooltip shows day, hour, keystrokes, and WPM
- [ ] Confirm Japanese strings display correctly