### PR TITLE
feat: bigram drill speed threshold filter

### DIFF
--- a/Sources/KeyLens/Charts+TrainingTab.swift
+++ b/Sources/KeyLens/Charts+TrainingTab.swift
@@ -12,8 +12,12 @@ extension ChartsView {
     /// Trigram drills are appended at the end: one repeated drill per top trigram.
     /// Trigram targets are not stored in training history (bigram targets only).
     private var currentTrainingSession: TrainingSession? {
-        guard !model.trainingScores.isEmpty else { return nil }
-        let base = SessionBuilder.build(from: model.trainingScores, config: sessionLength.config)
+        let scores: [BigramScore] = {
+            guard drillIKIThreshold > 0 else { return model.trainingScores }
+            return model.trainingScores.filter { $0.meanIKI >= drillIKIThreshold }
+        }()
+        guard !scores.isEmpty else { return nil }
+        let base = SessionBuilder.build(from: scores, config: sessionLength.config)
         let trigramDrills = trigramDrillsForSession()
         guard !trigramDrills.isEmpty else { return base }
         return TrainingSession(targets: base.targets,
@@ -246,6 +250,31 @@ extension ChartsView {
             }
             .pickerStyle(.segmented)
             .frame(maxWidth: 220)
+
+            // Speed threshold filter
+            HStack(spacing: 10) {
+                Text(L10n.shared.drillSpeedThresholdLabel)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                Stepper(value: $drillIKIThreshold, in: 0...2000, step: 10) {
+                    if drillIKIThreshold <= 0 {
+                        Text(L10n.shared.drillSpeedThresholdOff)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text(L10n.shared.drillSpeedThresholdValue(Int(drillIKIThreshold)))
+                    }
+                }
+                .onChange(of: drillIKIThreshold) { _ in trainingResetToken = UUID() }
+                if drillIKIThreshold > 0 {
+                    Button(L10n.shared.drillSpeedThresholdReset) {
+                        drillIKIThreshold = 0
+                        trainingResetToken = UUID()
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.blue)
+                    .font(.subheadline)
+                }
+            }
 
             if let session = currentTrainingSession, !session.drills.isEmpty {
                 InteractivePracticeView(

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -35,6 +35,9 @@ struct ChartsView: View {
     @State var keyTransitionTarget: String = ""
     /// Selected training session length — persisted across launches.
     @AppStorage("trainingSessionLength") var sessionLength: SessionLength = .normal
+    /// IKI speed threshold for drill selection (ms). Bigrams slower than this are included.
+    /// 0 = no filter (all ranked bigrams are used).
+    @AppStorage("bigramDrillIKIThreshold") var drillIKIThreshold: Double = 0
     /// Changed each time the user taps "New Session" to force InteractivePracticeView to reset.
     @State var trainingResetToken = UUID()
     /// Controls the confirmation alert for clearing training history.

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1674,6 +1674,14 @@ final class L10n {
     var trainingResultTime: String       { ja("時間", en: "Time") }
     var trainingAccuracyHelp: String     { ja("正確さ %", en: "Accuracy %") }
 
+    // Drill speed threshold filter (Issue #231)
+    var drillSpeedThresholdLabel: String { ja("スピード閾値:", en: "Speed threshold:") }
+    var drillSpeedThresholdOff: String   { ja("オフ (全バイグラム)", en: "Off (all bigrams)") }
+    func drillSpeedThresholdValue(_ ms: Int) -> String {
+        ja("≥ \(ms) ms のみ", en: "≥ \(ms) ms only")
+    }
+    var drillSpeedThresholdReset: String { ja("リセット", en: "Reset") }
+
     // MARK: - Chart Axis Labels
 
     var axisLabelKeys: String     { ja("キー数", en: "Keys") }


### PR DESCRIPTION
## Summary
- Adds a speed threshold stepper to the Practice Drills section in the Training tab
- When threshold > 0, only bigrams with `meanIKI ≥ threshold` are included in the drill session
- Threshold is persisted via `@AppStorage`; a Reset button appears when active

## Files changed
- `ChartsView.swift` — new `@AppStorage("bigramDrillIKIThreshold")` state var
- `Charts+TrainingTab.swift` — threshold filter in `currentTrainingSession`; stepper UI in `practiceDrillsSection`
- `L10n.swift` — bilingual strings for label, off state, value display, and reset button

Closes #231