### PR TITLE
perf: Phase 1 — defer LayoutComparison, fix Live tab double-timer, cap bigramIKIMap

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -49,6 +49,7 @@ extension ChartsView {
                     }
                     .padding(24)
                 }
+                .onAppear { model.reloadLayoutComparison() }
 
             case .fatigue:
                 ScrollView {

--- a/Sources/KeyLens/Charts+LiveTab.swift
+++ b/Sources/KeyLens/Charts+LiveTab.swift
@@ -70,15 +70,9 @@ extension ChartsView {
             }
         }
         .onAppear {
+            // Trigger an immediate refresh on tab appearance.
+            // Periodic refresh is handled by ChartsWindowController's 0.5s liveTimer.
             model.refreshLiveData()
-            liveTimer?.invalidate()
-            liveTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-                model.refreshLiveData()
-            }
-        }
-        .onDisappear {
-            liveTimer?.invalidate()
-            liveTimer = nil
         }
     }
 

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -19,8 +19,6 @@ struct ChartsView: View {
     @State var savedSection: String? = nil
     /// Stores each chart section's SwiftUI global frame and the Charts NSWindow reference.
     @State var snapperStore = SnapperStore()
-    /// Timer that drives real-time refresh on the Live tab.
-    @State var liveTimer: Timer? = nil
     /// Active sub-tab within the Live tab (Issue #271).
     @State var liveSubTab: LiveSubTab = .monitor
     /// Active sub-tab within the Activity tab (Issue #272).

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -86,8 +86,10 @@ final class ChartDataModel: ObservableObject {
 
     /// Loads all chart data on a background queue and publishes results to the main thread.
     /// Previously all queries ran synchronously on the main thread, causing stutter on window open.
+    /// LayoutComparison is excluded — it is deferred to the Layout sub-tab's onAppear (Issue #280).
     func reload() {
         isLoading = true
+        layoutComparison = nil  // Invalidate so it is recomputed on next Layout tab visit.
         let store = KeyCountStore.shared
         let ms    = MouseStore.shared
 
@@ -153,8 +155,13 @@ final class ChartDataModel: ObservableObject {
             let fatigueCurve       = store.todayHourlyFatigueCurve()
             // Issue #88: Training history
             let trainingHistory    = store.trainingHistory(limit: 20)
-            // Issue #84: Full IKI map for before/after comparison
-            let bigramIKIMap       = store.allBigramIKI()
+            // Issue #84: Full IKI map for before/after comparison.
+            // Issue #280: Bounded to bigrams between the top-40 keys (≤1,600 entries).
+            let topKeySet = Set(keyCounts.sorted { $0.value > $1.value }.prefix(40).map(\.key))
+            let bigramIKIMap = store.allBigramIKI().filter { bigram, _ in
+                guard let b = Bigram.parse(bigram) else { return true }
+                return topKeySet.contains(b.from) && topKeySet.contains(b.to)
+            }
             // Issue #209: Layer key efficiency
             let layerEfficiency    = store.layerEfficiency()
 
@@ -179,11 +186,6 @@ final class ChartDataModel: ObservableObject {
                 return MouseKeyboardBalanceEntry(id: entry.date, date: entry.date,
                                                  distancePts: entry.distancePts, keystrokes: keys)
             }.sorted { $0.date < $1.date }
-
-            // --- Layout comparison (CPU-heavy optimizer) ---
-            let bigramSnapshot = store.allBigramCounts
-            let keySnapshot    = store.allKeyCounts
-            let layoutResult   = LayoutComparison.make(bigramCounts: bigramSnapshot, keyCounts: keySnapshot)
 
             // Publish all results on the main thread in one batch.
             DispatchQueue.main.async { [weak self] in
@@ -229,14 +231,28 @@ final class ChartDataModel: ObservableObject {
                 self.mouseDirectionEntries      = mouseDirectionEntries
                 self.mouseDailyDirectionEntries = mouseDailyDirectionEntries
                 self.mouseKeyboardBalance       = mouseKeyboardBalance
-                self.layoutComparison           = layoutResult
-                self.isLayoutComparisonLoading  = false
                 self.isLoading                  = false
             }
         }
 
-        // Signal that the layout comparison is being computed (shown immediately).
+    }
+
+    /// Runs LayoutComparison on a background queue (Issue #280).
+    /// Called lazily from the Ergonomics → Layout sub-tab's onAppear instead of reload(),
+    /// because the optimizer runs ~1,800 ErgonomicSnapshot simulations and is CPU-heavy.
+    func reloadLayoutComparison() {
+        guard !isLayoutComparisonLoading, layoutComparison == nil else { return }
         isLayoutComparisonLoading = true
+        let store = KeyCountStore.shared
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            let bigramSnapshot = store.allBigramCounts
+            let keySnapshot    = store.allKeyCounts
+            let result         = LayoutComparison.make(bigramCounts: bigramSnapshot, keyCounts: keySnapshot)
+            DispatchQueue.main.async { [weak self] in
+                self?.layoutComparison          = result
+                self?.isLayoutComparisonLoading = false
+            }
+        }
     }
 
     /// Reloads key transition data for the given target key (Issue #98).


### PR DESCRIPTION
Closes #280

## Changes

### 1. Defer `LayoutComparison.make()` to Layout sub-tab `onAppear`
The optimizer runs ~1,800 `ErgonomicSnapshot.capture()` simulations and was the biggest single cost in `reload()`. It now runs via `reloadLayoutComparison()`, called lazily when the user first visits Ergonomics → Layout. `reload()` resets `layoutComparison = nil` to invalidate stale data on each window open.

### 2. Fix Live tab double-timer
`ChartsView` had a `@State var liveTimer` that created a 1s refresh timer on `onAppear`, running concurrently with `ChartsWindowController`'s 0.5s `liveTimer`. Both called `refreshLiveData()`. The view-level timer and its `@State` variable are removed; the controller timer is the sole owner of the refresh cycle.

### 3. Cap `bigramIKIMap` to top-40 keys
Bounds the map to ≤1,600 entries (top-40 keys × top-40 keys). `BigramHeatmapView` renders at most 20×20 = 400 bigrams; the slow-bigram key filter benefits from the full top-40 range.

## Test
- Open Charts → Ergonomics → Layout: spinner appears, then data loads (previously data appeared only after full reload delay)
- Open Charts → Live: speedometer and IKI chart update at 0.5s as before, no duplicate refreshes
- Open Charts → Ergonomics → Bigrams → Bigram Heatmap: renders correctly with top keys