### PR TITLE
feat: ErgonomicRecommendationEngine with row-reach penalty

### DIFF
--- a/Sources/KeyLens/KeyMetricsComputation.swift
+++ b/Sources/KeyLens/KeyMetricsComputation.swift
@@ -42,10 +42,22 @@ enum KeyMetricsComputation {
         let teCoeff = keyCounts.flatMap {
             layout.thumbEfficiencyCalculator.coefficient(counts: $0, layout: layout)
         } ?? 0.0
+        // Frequency-weighted mean row distance from home row (row 2), normalised to [0, 1].
+        var reachSum   = 0.0
+        var reachTotal = 0
+        if let kc = keyCounts {
+            for (key, count) in kc where count > 0 {
+                guard let pos = layout.current.position(for: key) else { continue }
+                reachSum   += Double(abs(pos.row - 2) * count)
+                reachTotal += count
+            }
+        }
+        let rowReach = reachTotal > 0 ? min(reachSum / Double(reachTotal) / 2.0, 1.0) : 0.0
         return engine.score(
             sameFingerRate:             Double(sfCount)  / Double(bigramCount),
             highStrainRate:             Double(hsCount)  / Double(bigramCount),
             thumbImbalanceRatio:        tiRatio,
+            rowReachScore:              rowReach,
             handAlternationRate:        Double(altCount) / Double(bigramCount),
             thumbEfficiencyCoefficient: teCoeff
         )

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -2067,12 +2067,12 @@ final class L10n {
     }
     var optimizerSwapHistoryTitle: String { ja("スワップ履歴",   en: "Swap History") }
     var optimizerScoreFormula: String     {
-        ja("スコア = 100 − 0.30×同指 − 0.25×高負荷 − 0.15×親指偏り + 0.20×交互 + 0.10×親指効率  (0〜100 に丸め)",
-           en: "score = 100 − 0.30×SFB − 0.25×HS − 0.15×TI + 0.20×Alt + 0.10×TE  (clamped 0–100)")
+        ja("スコア = 100 − 0.30×同指 − 0.25×高負荷 − 0.15×親指偏り − 0.20×行到達 + 0.20×交互 + 0.10×親指効率  (0〜100 に丸め)",
+           en: "score = 100 − 0.30×SFB − 0.25×HS − 0.15×TI − 0.20×Reach + 0.20×Alt + 0.10×TE  (clamped 0–100)")
     }
     var optimizerTravelNote: String       {
-        ja("※ フィンガートラベルはスコアに影響しません (参考値)。",
-           en: "* Finger travel is shown for reference only and does not affect the score.")
+        ja("※ 行到達 = 頻度加重平均のホーム行からの距離 (正規化)。フィンガートラベルは参考値のみ。",
+           en: "* Reach = frequency-weighted mean row distance from home row (normalised). Finger travel is shown for reference only.")
     }
 
     var liveTypingHint: String {

--- a/Sources/KeyLensCore/ErgonomicRecommendationEngine.swift
+++ b/Sources/KeyLensCore/ErgonomicRecommendationEngine.swift
@@ -1,0 +1,193 @@
+// ErgonomicRecommendationEngine.swift
+// Rule-based ergonomic recommendations from snapshot metrics.
+// スナップショット指標からルールベースの改善提案を生成する。
+
+import Foundation
+
+// MARK: - ErgonomicRecommendationSeverity
+
+/// Relative urgency of a recommendation.
+/// 提案の優先度。
+public enum ErgonomicRecommendationSeverity: Int, Equatable {
+    case low = 1
+    case medium = 2
+    case high = 3
+}
+
+// MARK: - ErgonomicRecommendation
+
+/// One actionable ergonomic suggestion generated from a snapshot.
+/// スナップショットから生成される1件の改善提案。
+public struct ErgonomicRecommendation: Equatable {
+    /// Stable identifier for this recommendation rule.
+    /// 提案ルールの安定ID。
+    public let id: String
+
+    /// L10n key for short title (UI string lives in app target).
+    /// 短いタイトル表示用のL10nキー。
+    public let titleKey: String
+
+    /// L10n key for detail/help text.
+    /// 詳細説明用のL10nキー。
+    public let detailKey: String
+
+    /// Relative urgency.
+    /// 優先度。
+    public let severity: ErgonomicRecommendationSeverity
+
+    /// Confidence in [0, 1].
+    /// 推定信頼度（0〜1）。
+    public let confidence: Double
+
+    /// Estimated score gain if the recommendation is addressed.
+    /// 対応した場合の推定スコア改善幅。
+    public let estimatedScoreGain: Double
+}
+
+// MARK: - ErgonomicRecommendationEngine
+
+/// Generates top ergonomic recommendations from `ErgonomicSnapshot`.
+/// `ErgonomicSnapshot` から改善提案の上位結果を生成する。
+public struct ErgonomicRecommendationEngine {
+    public let topK: Int
+    public let minimumSampleCount: Int
+    public let weights: ErgonomicScoreWeights
+
+    // Rule thresholds
+    public let sameFingerRateThreshold: Double
+    public let highStrainRateThreshold: Double
+    public let handAlternationFloor: Double
+    public let rowReachThreshold: Double
+
+    public init(
+        topK: Int = 3,
+        minimumSampleCount: Int = 120,
+        weights: ErgonomicScoreWeights = .default,
+        sameFingerRateThreshold: Double = 0.08,
+        highStrainRateThreshold: Double = 0.04,
+        handAlternationFloor: Double = 0.45,
+        rowReachThreshold: Double = 0.32
+    ) {
+        self.topK = max(1, topK)
+        self.minimumSampleCount = max(1, minimumSampleCount)
+        self.weights = weights
+        self.sameFingerRateThreshold = sameFingerRateThreshold
+        self.highStrainRateThreshold = highStrainRateThreshold
+        self.handAlternationFloor = handAlternationFloor
+        self.rowReachThreshold = rowReachThreshold
+    }
+
+    public static let `default` = ErgonomicRecommendationEngine()
+
+    /// Returns ranked recommendations.
+    ///
+    /// - Parameters:
+    ///   - snapshot: Current ergonomic snapshot.
+    ///   - sampleCount: Number of analyzed bigrams/key transitions.
+    /// - Returns: Top-K recommendations sorted by severity/confidence/gain/id.
+    public func topRecommendations(
+        from snapshot: ErgonomicSnapshot,
+        sampleCount: Int
+    ) -> [ErgonomicRecommendation] {
+        guard sampleCount >= minimumSampleCount else { return [] }
+
+        let sampleConfidence = min(Double(sampleCount) / Double(minimumSampleCount * 4), 1.0)
+        var recs: [ErgonomicRecommendation] = []
+
+        if snapshot.sameFingerRate > sameFingerRateThreshold {
+            let exceed = snapshot.sameFingerRate - sameFingerRateThreshold
+            let gain = min(exceed * weights.sameFingerPenalty * 100.0, 12.0)
+            recs.append(
+                ErgonomicRecommendation(
+                    id: "same_finger_repetition",
+                    titleKey: "ergoRec.sameFinger.title",
+                    detailKey: "ergoRec.sameFinger.detail",
+                    severity: severity(for: exceed, high: 0.07, medium: 0.03),
+                    confidence: calibratedConfidence(exceed: exceed, span: 0.12, sampleConfidence: sampleConfidence),
+                    estimatedScoreGain: gain
+                )
+            )
+        }
+
+        if snapshot.highStrainRate > highStrainRateThreshold {
+            let exceed = snapshot.highStrainRate - highStrainRateThreshold
+            let gain = min(exceed * weights.highStrainPenalty * 100.0, 10.0)
+            recs.append(
+                ErgonomicRecommendation(
+                    id: "outer_column_load",
+                    titleKey: "ergoRec.outerColumn.title",
+                    detailKey: "ergoRec.outerColumn.detail",
+                    severity: severity(for: exceed, high: 0.06, medium: 0.025),
+                    confidence: calibratedConfidence(exceed: exceed, span: 0.10, sampleConfidence: sampleConfidence),
+                    estimatedScoreGain: gain
+                )
+            )
+        }
+
+        if snapshot.handAlternationRate < handAlternationFloor {
+            let exceed = handAlternationFloor - snapshot.handAlternationRate
+            let gain = min(exceed * weights.alternationReward * 100.0, 8.0)
+            recs.append(
+                ErgonomicRecommendation(
+                    id: "weak_hand_alternation",
+                    titleKey: "ergoRec.alternation.title",
+                    detailKey: "ergoRec.alternation.detail",
+                    severity: severity(for: exceed, high: 0.20, medium: 0.10),
+                    confidence: calibratedConfidence(exceed: exceed, span: 0.35, sampleConfidence: sampleConfidence),
+                    estimatedScoreGain: gain
+                )
+            )
+        }
+
+        if snapshot.rowReachScore > rowReachThreshold {
+            let exceed = snapshot.rowReachScore - rowReachThreshold
+            let gain = min(exceed * weights.rowReachPenalty * 100.0, 9.0)
+            recs.append(
+                ErgonomicRecommendation(
+                    id: "high_row_reach",
+                    titleKey: "ergoRec.rowReach.title",
+                    detailKey: "ergoRec.rowReach.detail",
+                    severity: severity(for: exceed, high: 0.18, medium: 0.08),
+                    confidence: calibratedConfidence(exceed: exceed, span: 0.28, sampleConfidence: sampleConfidence),
+                    estimatedScoreGain: gain
+                )
+            )
+        }
+
+        return recs
+            .sorted {
+                if $0.severity.rawValue != $1.severity.rawValue {
+                    return $0.severity.rawValue > $1.severity.rawValue
+                }
+                if $0.confidence != $1.confidence {
+                    return $0.confidence > $1.confidence
+                }
+                if $0.estimatedScoreGain != $1.estimatedScoreGain {
+                    return $0.estimatedScoreGain > $1.estimatedScoreGain
+                }
+                return $0.id < $1.id
+            }
+            .prefix(topK)
+            .map { $0 }
+    }
+
+    private func severity(
+        for exceed: Double,
+        high: Double,
+        medium: Double
+    ) -> ErgonomicRecommendationSeverity {
+        if exceed >= high { return .high }
+        if exceed >= medium { return .medium }
+        return .low
+    }
+
+    private func calibratedConfidence(
+        exceed: Double,
+        span: Double,
+        sampleConfidence: Double
+    ) -> Double {
+        guard span > 0 else { return 0.0 }
+        let signal = min(max(exceed / span, 0.0), 1.0)
+        return min(max(0.35 + signal * 0.65, 0.0), 1.0) * sampleConfidence
+    }
+}

--- a/Sources/KeyLensCore/ErgonomicScoreEngine.swift
+++ b/Sources/KeyLensCore/ErgonomicScoreEngine.swift
@@ -8,6 +8,7 @@
 //     - weights.sameFingerPenalty    × (sameFingerRate   × 100)
 //     - weights.highStrainPenalty    × (highStrainRate   × 100)
 //     - weights.thumbImbalancePenalty× (thumbImbalanceRatio × 100)
+//     - weights.rowReachPenalty      × (rowReachScore    × 100)
 //     + weights.alternationReward    × (handAlternationRate × 100)
 //     + weights.thumbEfficiencyBonus × (min(teCoeff / teMax, 1.0) × 100)
 //
@@ -45,6 +46,7 @@ import Foundation
 /// | sameFingerPenalty     | negative  | 0.30    |
 /// | highStrainPenalty     | negative  | 0.25    |
 /// | thumbImbalancePenalty | negative  | 0.15    |
+/// | rowReachPenalty       | negative  | 0.20    |
 /// | alternationReward     | positive  | 0.20    |
 /// | thumbEfficiencyBonus  | positive  | 0.10    |
 ///
@@ -63,6 +65,11 @@ public struct ErgonomicScoreWeights: Equatable {
     /// 親指偏りペナルティの重み。方向：減点。
     public let thumbImbalancePenalty: Double
 
+    /// Weight for row-reach penalty (Issue #293). Direction: negative.
+    /// Penalises layouts that place frequent keys far from the home row.
+    /// 行到達ペナルティの重み。頻繁に使うキーがホーム行から離れた行にあるほど減点。方向：減点。
+    public let rowReachPenalty: Double
+
     /// Weight for hand alternation reward (Issue #25). Direction: positive.
     /// 手交互打鍵報酬の重み。方向：加点。
     public let alternationReward: Double
@@ -75,28 +82,31 @@ public struct ErgonomicScoreWeights: Equatable {
         sameFingerPenalty: Double,
         highStrainPenalty: Double,
         thumbImbalancePenalty: Double,
+        rowReachPenalty: Double,
         alternationReward: Double,
         thumbEfficiencyBonus: Double
     ) {
         self.sameFingerPenalty     = sameFingerPenalty
         self.highStrainPenalty     = highStrainPenalty
         self.thumbImbalancePenalty = thumbImbalancePenalty
+        self.rowReachPenalty       = rowReachPenalty
         self.alternationReward     = alternationReward
         self.thumbEfficiencyBonus  = thumbEfficiencyBonus
     }
 
     // MARK: - Default
 
-    /// Default weights as specified in Issue #29.
+    /// Default weights as specified in Issue #29, extended with rowReachPenalty (Issue #293).
     ///
-    /// Penalty total: 0.30 + 0.25 + 0.15 = 0.70 (max deduction: 70 pts)
+    /// Penalty total: 0.30 + 0.25 + 0.15 + 0.20 = 0.90 (max deduction: 90 pts)
     /// Reward total:  0.20 + 0.10 = 0.30 (max addition: 30 pts)
     ///
-    /// Issue #29 仕様のデフォルト重みテーブル。
+    /// Issue #29 仕様のデフォルト重みテーブル (Issue #293 の行到達ペナルティを追加)。
     public static let `default` = ErgonomicScoreWeights(
         sameFingerPenalty:     0.30,
         highStrainPenalty:     0.25,
         thumbImbalancePenalty: 0.15,
+        rowReachPenalty:       0.20,
         alternationReward:     0.20,
         thumbEfficiencyBonus:  0.10
     )
@@ -159,25 +169,29 @@ public struct ErgonomicScoreEngine: Equatable {
     ///   - sameFingerRate:             Fraction of bigrams using the same finger. [0, 1]
     ///   - highStrainRate:             Fraction of bigrams classified as high-strain. [0, 1]
     ///   - thumbImbalanceRatio:        Normalised left/right thumb usage imbalance. [0, 1]
+    ///   - rowReachScore:              Frequency-weighted mean row distance from home row,
+    ///                                 normalised to [0, 1] (0 = all keys on home row, 1 = max reach). [0, 1]
     ///   - handAlternationRate:        Fraction of bigrams that alternate hands. [0, 1]
     ///   - thumbEfficiencyCoefficient: Thumb keystrokes / (total × expectedRatio). [0, ∞]
     /// - Returns: Ergonomic score clamped to [0, 100]. Higher is better.
     ///
-    /// 5つの正規化済みサブ指標からエルゴノミクススコアを算出する。高いほど良好。
+    /// 6つの正規化済みサブ指標からエルゴノミクススコアを算出する。高いほど良好。
     public func score(
         sameFingerRate:             Double,
         highStrainRate:             Double,
         thumbImbalanceRatio:        Double,
+        rowReachScore:              Double,
         handAlternationRate:        Double,
         thumbEfficiencyCoefficient: Double
     ) -> Double {
         // Normalise each sub-metric to [0, 100].
         // 各サブ指標を [0, 100] に正規化する。
-        let sfb100 = sameFingerRate  * 100
-        let hs100  = highStrainRate  * 100
-        let ti100  = thumbImbalanceRatio * 100
-        let alt100 = handAlternationRate * 100
-        let te100  = thumbEfficiencyMax > 0
+        let sfb100    = sameFingerRate      * 100
+        let hs100     = highStrainRate      * 100
+        let ti100     = thumbImbalanceRatio * 100
+        let reach100  = rowReachScore       * 100
+        let alt100    = handAlternationRate * 100
+        let te100     = thumbEfficiencyMax > 0
             ? min(thumbEfficiencyCoefficient / thumbEfficiencyMax, 1.0) * 100
             : 0.0
 
@@ -185,6 +199,7 @@ public struct ErgonomicScoreEngine: Equatable {
             - weights.sameFingerPenalty     * sfb100
             - weights.highStrainPenalty     * hs100
             - weights.thumbImbalancePenalty * ti100
+            - weights.rowReachPenalty       * reach100
             + weights.alternationReward     * alt100
             + weights.thumbEfficiencyBonus  * te100
 

--- a/Sources/KeyLensCore/ErgonomicSnapshot.swift
+++ b/Sources/KeyLensCore/ErgonomicSnapshot.swift
@@ -15,6 +15,7 @@
 //   - handAlternationRate        [0, 1]    fraction of bigrams that alternate hands
 //   - thumbImbalanceRatio        [0, 1]    normalised left/right thumb usage imbalance
 //   - thumbEfficiencyCoefficient [0, ∞]   thumb keystrokes / (total × expectedRatio)
+//   - rowReachScore              [0, 1]    frequency-weighted mean row distance from home row (lower = better)
 //   - estimatedTravelDistance    [0, ∞]   total finger travel in grid units (lower = better)
 //   - typingStyle                TypingStyle detected typing context
 //   - fatigueLevel               FatigueLevel detected typing fatigue
@@ -68,6 +69,11 @@ public struct ErgonomicSnapshot: Equatable {
 
     // MARK: - Travel distance
 
+    /// Frequency-weighted mean row distance from the home row (row 2), normalised to [0, 1].
+    /// 0 = all typed keys on home row; 1 = maximum reach (number row or thumb row). Lower is better.
+    /// ホーム行(row 2)からの頻度加重平均行距離（0〜1 正規化）。低いほど良好。
+    public let rowReachScore: Double
+
     /// Estimated total finger travel distance (in grid units). Lower is better.
     /// 総指移動距離の推定値（グリッド単位）。低いほど良好。
     public let estimatedTravelDistance: Double
@@ -87,6 +93,7 @@ public struct ErgonomicSnapshot: Equatable {
         handAlternationRate: Double,
         thumbImbalanceRatio: Double,
         thumbEfficiencyCoefficient: Double,
+        rowReachScore: Double,
         estimatedTravelDistance: Double,
         typingStyle: TypingStyle = .unknown,
         fatigueLevel: FatigueLevel = .low
@@ -97,6 +104,7 @@ public struct ErgonomicSnapshot: Equatable {
         self.handAlternationRate        = handAlternationRate
         self.thumbImbalanceRatio        = thumbImbalanceRatio
         self.thumbEfficiencyCoefficient = thumbEfficiencyCoefficient
+        self.rowReachScore              = rowReachScore
         self.estimatedTravelDistance    = estimatedTravelDistance
         self.typingStyle                = typingStyle
         self.fatigueLevel               = fatigueLevel
@@ -131,6 +139,7 @@ public struct ErgonomicSnapshot: Equatable {
                 sameFingerRate: 0, highStrainRate: 0,
                 handAlternationRate: 0,
                 thumbImbalanceRatio: 0, thumbEfficiencyCoefficient: 0,
+                rowReachScore: 0,
                 estimatedTravelDistance: 0,
                 typingStyle: .unknown, fatigueLevel: .low
             )
@@ -182,6 +191,19 @@ public struct ErgonomicSnapshot: Equatable {
         let teCoeff = layout.thumbEfficiencyCalculator
             .coefficient(counts: keyCounts, layout: layout) ?? 0.0
 
+        // --- Row-reach score --------------------------------------------------------
+        // Frequency-weighted mean |row − 2| (home row = 2), normalised to [0, 1].
+        // Max row distance from home is 2 (number row = 0, thumb row = 4), so divide by 2.
+        // 頻度加重平均の行距離（ホーム行 = row 2 基準）。最大距離 2 で正規化して [0, 1] にする。
+        var reachSum   = 0.0
+        var reachTotal = 0
+        for (key, count) in keyCounts where count > 0 {
+            guard let pos = layout.current.position(for: key) else { continue }
+            reachSum   += Double(abs(pos.row - 2) * count)
+            reachTotal += count
+        }
+        let rowReach = reachTotal > 0 ? min(reachSum / Double(reachTotal) / 2.0, 1.0) : 0.0
+
         // --- Travel distance --------------------------------------------------------
         let travel = estimator.totalTravel(counts: bigramCounts, layout: layout.current)
 
@@ -190,6 +212,7 @@ public struct ErgonomicSnapshot: Equatable {
             sameFingerRate:             sfbRate,
             highStrainRate:             hsRate,
             thumbImbalanceRatio:        tiRatio,
+            rowReachScore:              rowReach,
             handAlternationRate:        altRate,
             thumbEfficiencyCoefficient: teCoeff
         )
@@ -214,6 +237,7 @@ public struct ErgonomicSnapshot: Equatable {
             handAlternationRate:        altRate,
             thumbImbalanceRatio:        tiRatio,
             thumbEfficiencyCoefficient: teCoeff,
+            rowReachScore:              rowReach,
             estimatedTravelDistance:    travel,
             typingStyle:                style,
             fatigueLevel:               fatigue

--- a/Tests/KeyLensTests/ErgonomicRecommendationEngineTests.swift
+++ b/Tests/KeyLensTests/ErgonomicRecommendationEngineTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+@testable import KeyLensCore
+
+final class ErgonomicRecommendationEngineTests: XCTestCase {
+
+    private let engine = ErgonomicRecommendationEngine.default
+
+    private func snapshot(
+        sameFingerRate: Double = 0,
+        highStrainRate: Double = 0,
+        handAlternationRate: Double = 0.5,
+        rowReachScore: Double = 0,
+        score: Double = 100
+    ) -> ErgonomicSnapshot {
+        ErgonomicSnapshot(
+            ergonomicScore: score,
+            sameFingerRate: sameFingerRate,
+            highStrainRate: highStrainRate,
+            handAlternationRate: handAlternationRate,
+            thumbImbalanceRatio: 0,
+            thumbEfficiencyCoefficient: 0,
+            rowReachScore: rowReachScore,
+            estimatedTravelDistance: 0
+        )
+    }
+
+    func testLowSampleCount_returnsEmptySafely() {
+        let recs = engine.topRecommendations(
+            from: snapshot(sameFingerRate: 0.25, highStrainRate: 0.20, handAlternationRate: 0.10, rowReachScore: 0.80),
+            sampleCount: 40
+        )
+        XCTAssertTrue(recs.isEmpty)
+    }
+
+    func testSameFingerTrigger_producesExpectedRuleId() {
+        let recs = engine.topRecommendations(
+            from: snapshot(sameFingerRate: 0.18),
+            sampleCount: 300
+        )
+        XCTAssertTrue(recs.contains { $0.id == "same_finger_repetition" })
+    }
+
+    func testHighStrainTrigger_producesOuterColumnRule() {
+        let recs = engine.topRecommendations(
+            from: snapshot(highStrainRate: 0.12),
+            sampleCount: 300
+        )
+        XCTAssertTrue(recs.contains { $0.id == "outer_column_load" })
+    }
+
+    func testWeakAlternationTrigger_producesAlternationRule() {
+        let recs = engine.topRecommendations(
+            from: snapshot(handAlternationRate: 0.20),
+            sampleCount: 300
+        )
+        XCTAssertTrue(recs.contains { $0.id == "weak_hand_alternation" })
+    }
+
+    func testRowReachTrigger_producesRowReachRule() {
+        let recs = engine.topRecommendations(
+            from: snapshot(rowReachScore: 0.60),
+            sampleCount: 300
+        )
+        XCTAssertTrue(recs.contains { $0.id == "high_row_reach" })
+    }
+
+    func testNoRuleTriggered_returnsEmpty() {
+        let recs = engine.topRecommendations(
+            from: snapshot(
+                sameFingerRate: 0.04,
+                highStrainRate: 0.02,
+                handAlternationRate: 0.56,
+                rowReachScore: 0.18
+            ),
+            sampleCount: 300
+        )
+        XCTAssertTrue(recs.isEmpty)
+    }
+
+    func testDeterministicOrder_sameInputSameOutput() {
+        let snap = snapshot(
+            sameFingerRate: 0.21,
+            highStrainRate: 0.15,
+            handAlternationRate: 0.12,
+            rowReachScore: 0.72
+        )
+        let first = engine.topRecommendations(from: snap, sampleCount: 500)
+        let second = engine.topRecommendations(from: snap, sampleCount: 500)
+        XCTAssertEqual(first, second)
+    }
+
+    func testTopK_isCappedAtThreeForDefault() {
+        let recs = engine.topRecommendations(
+            from: snapshot(
+                sameFingerRate: 0.30,
+                highStrainRate: 0.30,
+                handAlternationRate: 0.10,
+                rowReachScore: 0.90
+            ),
+            sampleCount: 400
+        )
+        XCTAssertLessThanOrEqual(recs.count, 3)
+    }
+
+    func testRegression_scoreComputationPathUnchanged() {
+        let scoreEngine = ErgonomicScoreEngine.default
+        let s1 = scoreEngine.score(
+            sameFingerRate: 0.12,
+            highStrainRate: 0.06,
+            thumbImbalanceRatio: 0.15,
+            rowReachScore: 0.45,
+            handAlternationRate: 0.38,
+            thumbEfficiencyCoefficient: 1.1
+        )
+
+        _ = engine.topRecommendations(
+            from: snapshot(
+                sameFingerRate: 0.12,
+                highStrainRate: 0.06,
+                handAlternationRate: 0.38,
+                rowReachScore: 0.45,
+                score: s1
+            ),
+            sampleCount: 450
+        )
+
+        let s2 = scoreEngine.score(
+            sameFingerRate: 0.12,
+            highStrainRate: 0.06,
+            thumbImbalanceRatio: 0.15,
+            rowReachScore: 0.45,
+            handAlternationRate: 0.38,
+            thumbEfficiencyCoefficient: 1.1
+        )
+        XCTAssertEqual(s1, s2, accuracy: 1e-9)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ErgonomicRecommendationEngine` — rule-based engine that turns `ErgonomicSnapshot` metrics into top-K actionable recommendations (same-finger repetition, outer-column load, weak hand alternation, high row-reach)
- Adds `rowReachScore` field to `ErgonomicSnapshot` and plugs it into `ErgonomicScoreEngine` as a 0.20-weight penalty (Issue #293)
- Updates L10n score formula string to include the new row-reach term (#300)
- Adds `ErgonomicRecommendationEngineTests` covering all four rules, low-sample guard, determinism, top-K cap, and regression (#301)

## Test plan
- [ ] Build succeeds (`swift build -c release`)
- [ ] Run `ErgonomicRecommendationEngineTests` and `ErgonomicScoreEngineTests` in Xcode — all pass
- [ ] Ergonomics tab score formula footnote shows row-reach term

Closes #293, #298, #300, #301