### PR TITLE
feat: session rhythm heatmap in Activity > Patterns (#292)

### DIFF
--- a/Sources/KeyLens/Charts+ActivityTab.swift
+++ b/Sources/KeyLens/Charts+ActivityTab.swift
@@ -42,6 +42,9 @@ extension ChartsView {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 40) {
                         chartSection(L10n.shared.chartTitleWeeklyHeatmap, helpText: L10n.shared.helpWeeklyHeatmap) { weeklyHeatmapChart }
+                        chartSection(L10n.shared.chartTitleSessionRhythm, helpText: L10n.shared.helpSessionRhythm) {
+                            SessionWeeklyHeatmapView(cells: model.sessionHeatmapCells)
+                        }
                         chartSection(L10n.shared.chartTitleHourlyDistribution, helpText: L10n.shared.helpHourlyDistribution) { hourlyDistributionChart }
                     }
                     .padding(24)
@@ -501,6 +504,137 @@ extension ChartsView {
                 .chartYAxisLabel(L10n.shared.axisLabelMinutes, alignment: .trailing)
                 .frame(height: 140)
             }
+        }
+    }
+}
+
+// MARK: - Issue #292: SessionWeeklyHeatmapView (7 rows × 24 cols, session count / avg duration)
+
+/// Interactive 7-row (Mon–Sun) × 24-column (0–23h) heatmap for session rhythm.
+/// Metric toggle: Session Count / Avg Duration.
+struct SessionWeeklyHeatmapView: View {
+    let cells: [SessionHeatmapCell]
+
+    @State private var metric: SessionHeatmapMetric = .count
+    @State private var hoveredCell: SessionHeatmapCell? = nil
+
+    enum SessionHeatmapMetric { case count, duration }
+
+    private let cellW:  CGFloat = 22
+    private let cellH:  CGFloat = 18
+    private let labelW: CGFloat = 30
+    private let headerH: CGFloat = 20
+
+    private var lookup: [Int: SessionHeatmapCell] {
+        Dictionary(uniqueKeysWithValues: cells.map { ($0.weekday * 24 + $0.hour, $0) })
+    }
+
+    private var maxValue: Double {
+        switch metric {
+        case .count:    return cells.map(\.avgCount).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+        case .duration: return cells.map(\.avgDurationMinutes).max().flatMap { $0 > 0 ? $0 : nil } ?? 1
+        }
+    }
+
+    var body: some View {
+        if cells.isEmpty {
+            Text(L10n.shared.noDataYet)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                Picker("", selection: $metric) {
+                    Text(L10n.shared.sessionRhythmMetricCount).tag(SessionHeatmapMetric.count)
+                    Text(L10n.shared.sessionRhythmMetricDuration).tag(SessionHeatmapMetric.duration)
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 200)
+
+                grid
+                tooltipLine
+                legend
+            }
+        }
+    }
+
+    private var weekdayDisplayOrder: [Int] { [1, 2, 3, 4, 5, 6, 0] }
+
+    private var grid: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                Spacer().frame(width: labelW)
+                ForEach(0..<24, id: \.self) { h in
+                    Text(h % 4 == 0 ? String(format: "%02d", h) : "")
+                        .font(.system(size: 8))
+                        .foregroundStyle(.secondary)
+                        .frame(width: cellW, height: headerH, alignment: .leading)
+                }
+            }
+            ForEach(weekdayDisplayOrder, id: \.self) { wd in
+                weekdayRow(wd: wd)
+            }
+        }
+    }
+
+    private func weekdayRow(wd: Int) -> some View {
+        let abbrs = L10n.shared.weekdayAbbrs
+        let label = wd < abbrs.count ? abbrs[wd] : ""
+        return HStack(spacing: 0) {
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .frame(width: labelW, height: cellH, alignment: .trailing)
+                .padding(.trailing, 4)
+            ForEach(0..<24, id: \.self) { h in
+                let cell = lookup[wd * 24 + h]
+                let value: Double = {
+                    guard let c = cell else { return 0 }
+                    switch metric {
+                    case .count:    return c.avgCount
+                    case .duration: return c.avgDurationMinutes
+                    }
+                }()
+                let intensity = maxValue > 0 ? value / maxValue : 0
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(Color.teal.opacity(0.06 + intensity * 0.88))
+                    .frame(width: cellW - 2, height: cellH - 2)
+                    .padding(1)
+                    .onHover { isHovered in hoveredCell = isHovered ? cell : nil }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var tooltipLine: some View {
+        let l = L10n.shared
+        if let cell = hoveredCell {
+            let abbrs  = l.weekdayAbbrs
+            let dayName = cell.weekday < abbrs.count ? abbrs[cell.weekday] : ""
+            let hourStr = String(format: "%02d:00", cell.hour)
+            let countPart = "\(Int(cell.avgCount.rounded())) \(l.sessionRhythmTooltipCount)"
+            let durPart   = "  ·  \(String(format: "%.0f", cell.avgDurationMinutes)) \(l.sessionRhythmTooltipDuration)"
+            Text("\(dayName) \(hourStr)  ·  \(countPart)\(durPart)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else {
+            Text(" ").font(.caption)
+        }
+    }
+
+    private var legend: some View {
+        HStack(spacing: 4) {
+            Text(L10n.shared.calendarLegendLow)
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
+            ForEach([0.1, 0.3, 0.5, 0.7, 1.0], id: \.self) { i in
+                Rectangle()
+                    .fill(Color.teal.opacity(0.06 + i * 0.88))
+                    .frame(width: 10, height: 10)
+                    .cornerRadius(2)
+            }
+            Text(L10n.shared.calendarLegendHigh)
+                .font(.system(size: 8))
+                .foregroundStyle(.secondary)
         }
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -292,6 +292,18 @@ struct HeatmapCell: Identifiable {
     }
 }
 
+// MARK: - Issue #292: Session Rhythm Heatmap
+
+/// One cell in the 7×24 session rhythm heatmap: session count and average duration for a (weekday, hour) pair.
+/// セッションリズムヒートマップの1セル：曜日×時刻ごとのセッション数・平均時間。
+struct SessionHeatmapCell: Identifiable {
+    let id: Int                   // weekday * 24 + hour
+    let weekday: Int              // 0 = Sunday … 6 = Saturday
+    let hour: Int                 // 0–23
+    let avgCount: Double          // average session count across all matching weekday+hour slots
+    let avgDurationMinutes: Double // average session duration in minutes
+}
+
 // MARK: - Issue #63: Hourly fatigue entry
 
 /// One data point in the Fatigue Curve chart: per-hour WPM and ergonomic rates for today.

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -81,6 +81,8 @@ final class ChartDataModel: ObservableObject {
     @Published var bigramIKIMap:               [String: Double]              = [:]
     // Issue #78: Weekly Activity Heatmap
     @Published var weeklyHeatmap:              [HeatmapCell]                 = []
+    // Issue #292: Session Rhythm Heatmap
+    @Published var sessionHeatmapCells:        [SessionHeatmapCell]          = []
     // Issue #209: Layer key efficiency
     @Published var layerEfficiency:            [LayerEfficiencyEntry]        = []
     // Issue #258: background loading state
@@ -151,6 +153,8 @@ final class ChartDataModel: ObservableObject {
             let layoutEfficiency   = store.layoutEfficiencyScores()
             // Issue #60: session detection
             let sessionSummaries   = store.allSessionSummaries()
+            // Issue #292: session rhythm heatmap
+            let sessionHeatmapCells = store.sessionRhythmHeatmap()
             // Issue #290: consecutive active-day streak
             let sessionStreakDays   = Self.computeSessionStreak(sessionSummaries)
             // Issue #90: Training
@@ -230,8 +234,9 @@ final class ChartDataModel: ObservableObject {
                 self.slowBigrams          = slowBigrams
                 self.fingerIKI            = fingerIKI
                 self.layoutEfficiency     = layoutEfficiency
-                self.sessionSummaries     = sessionSummaries
-                self.sessionStreakDays    = sessionStreakDays
+                self.sessionSummaries      = sessionSummaries
+                self.sessionHeatmapCells   = sessionHeatmapCells
+                self.sessionStreakDays     = sessionStreakDays
                 self.trainingScores       = trainingScores
                 self.trainingTrigramScores = trainingTrigramScores
                 self.fatigueCurve         = fatigueCurve

--- a/Sources/KeyLens/KeyCountStore+SQLite.swift
+++ b/Sources/KeyLens/KeyCountStore+SQLite.swift
@@ -444,6 +444,38 @@ extension KeyCountStore {
 
 extension KeyCountStore {
 
+    /// Returns 7×24 session rhythm heatmap cells aggregated by weekday × hour.
+    /// Uses local time via SQLite's 'localtime' modifier.
+    /// Must NOT be called on `queue` to avoid deadlock.
+    func sessionRhythmHeatmap() -> [SessionHeatmapCell] {
+        guard let db = dbQueue else { return [] }
+        let rows = (try? db.read { db in
+            try Row.fetchAll(db, sql: """
+                SELECT
+                    CAST(strftime('%w', start_time, 'unixepoch', 'localtime') AS INTEGER) AS wd,
+                    CAST(strftime('%H', start_time, 'unixepoch', 'localtime') AS INTEGER) AS hr,
+                    COUNT(*) AS cnt,
+                    AVG(end_time - start_time) / 60.0 AS avg_dur
+                FROM sessions
+                WHERE end_time > start_time AND keystroke_count > 0
+                GROUP BY wd, hr
+                """)
+        }) ?? []
+        return rows.map { row in
+            let wd:  Int    = row["wd"]
+            let hr:  Int    = row["hr"]
+            let cnt: Double = Double(row["cnt"] as Int)
+            let dur: Double = row["avg_dur"] ?? 0
+            return SessionHeatmapCell(
+                id: wd * 24 + hr,
+                weekday: wd,
+                hour: hr,
+                avgCount: cnt,
+                avgDurationMinutes: dur
+            )
+        }
+    }
+
     /// Returns per-day session summaries (count, total minutes, longest session) from SQLite.
     /// Must NOT be called on `queue` to avoid deadlock.
     func allSessionSummaries() -> [DailySessionSummary] {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1596,6 +1596,27 @@ final class L10n {
         ja("—", en: "—")
     }
 
+    // Issue #292: Session Rhythm Heatmap
+    var chartTitleSessionRhythm: String {
+        ja("セッションリズム", en: "Session Rhythm")
+    }
+    var helpSessionRhythm: String {
+        ja("曜日×時刻ごとのセッション数・平均時間を表示します。ピークタイムや習慣的な作業パターンを把握できます。",
+           en: "Shows session count and average duration broken down by day-of-week × hour. Reveals your peak times and habitual work patterns.")
+    }
+    var sessionRhythmMetricCount: String {
+        ja("セッション数", en: "Count")
+    }
+    var sessionRhythmMetricDuration: String {
+        ja("平均時間", en: "Duration")
+    }
+    var sessionRhythmTooltipCount: String {
+        ja("セッション", en: "sessions")
+    }
+    var sessionRhythmTooltipDuration: String {
+        ja("分", en: "min")
+    }
+
     var calendarLegendLow: String {
         ja("少", en: "Low")
     }


### PR DESCRIPTION
## Summary
- Adds a 7×24 (day-of-week × hour) session rhythm heatmap to the Activity → Patterns sub-tab
- Metric toggle: **Session Count** / **Avg Duration (min)**
- Hover tooltip shows day, hour, count, and duration for each cell
- Teal color scale to visually distinguish from the blue keystroke heatmap
- Empty-state shown when no session data exists

## Files changed
| File | Change |
|---|---|
| `ChartsDataTypes.swift` | New `SessionHeatmapCell` struct |
| `KeyCountStore+SQLite.swift` | New `sessionRhythmHeatmap()` SQL query (weekday × hour aggregation) |
| `ChartsWindowController.swift` | `@Published var sessionHeatmapCells`, fetched in `reload()` |
| `Charts+ActivityTab.swift` | New `SessionWeeklyHeatmapView`, wired into Patterns sub-tab |
| `L10n.swift` | Section title, help text, metric toggle labels, tooltip unit strings (EN + JA) |

## Test plan
- [ ] Build and install (`./build.sh --install`)
- [ ] Open Charts → Activity → Patterns — verify Session Rhythm section appears below keystroke heatmap
- [ ] Hover over cells — verify tooltip shows correct day/hour/count/duration
- [ ] Toggle Count ↔ Duration — verify color scale updates
- [ ] Verify teal color distinguishes from blue keystroke heatmap
- [ ] Switch language EN ↔ JA — verify all labels update
- [ ] Verify light/dark mode rendering