### PR TITLE
feat: thumb cluster configuration for DIY keyboards

### DIFF
--- a/Sources/KeyLens/Charts+ErgonomicsTab.swift
+++ b/Sources/KeyLens/Charts+ErgonomicsTab.swift
@@ -28,7 +28,10 @@ extension ChartsView {
 
             switch ergoSubTab {
             case .recommendations:
-                ErgoRecommendationsView(recs: model.ergoRecommendations)
+                VStack(spacing: 0) {
+                    ThumbClusterSettingsView(showConfig: $showThumbClusterConfig, onChanged: { model.reload() })
+                    ErgoRecommendationsView(recs: model.ergoRecommendations)
+                }
 
             case .bigrams:
                 ScrollView {
@@ -852,5 +855,124 @@ private struct ErgoRecommendationsView: View {
         case .medium: return .orange
         case .low:    return .secondary
         }
+    }
+}
+
+// MARK: - Thumb Cluster Settings (Issue #333)
+
+private struct ThumbClusterSettingsView: View {
+    @Binding var showConfig: Bool
+    let onChanged: () -> Void
+
+    @ObservedObject private var theme = ThemeStore.shared
+    @State private var selectedKeys: Set<String> = []
+
+    var body: some View {
+        let l = L10n.shared
+        let currentKeys = LayoutRegistry.shared.activeProfile.thumbConfig?.thumbKeys ?? []
+
+        HStack(spacing: 10) {
+            Image(systemName: "hand.point.up.left")
+                .foregroundColor(theme.accentColor)
+                .font(.system(size: 15))
+
+            if currentKeys.isEmpty {
+                Text(l.thumbClusterConfigNone)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(l.thumbClusterConfigActive)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                ForEach(currentKeys.sorted(), id: \.self) { key in
+                    Text(key)
+                        .font(.system(size: 11, weight: .semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(theme.accentColor.opacity(0.15))
+                        .cornerRadius(4)
+                }
+            }
+
+            Spacer()
+
+            Button(l.thumbClusterConfigTitle) {
+                selectedKeys = LayoutRegistry.shared.activeProfile.thumbConfig?.thumbKeys ?? []
+                showConfig = true
+            }
+            .buttonStyle(.borderless)
+            .font(.system(size: 12))
+            .foregroundColor(theme.accentColor)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
+        .background(Color(NSColor.controlBackgroundColor).opacity(0.6))
+        .sheet(isPresented: $showConfig) {
+            thumbConfigSheet(onChanged: onChanged)
+        }
+    }
+
+    private func thumbConfigSheet(onChanged: @escaping () -> Void) -> some View {
+        let l = L10n.shared
+        return VStack(alignment: .leading, spacing: 20) {
+            Text(l.thumbClusterConfigTitle)
+                .font(.headline)
+
+            Text(l.thumbClusterConfigHelp)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 8) {
+                Text(l.thumbClusterConfigPresetLabel + ":")
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                Button(l.thumbClusterConfigPresetNone) {
+                    selectedKeys = []
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                Button(l.thumbClusterConfigPresetCommon) {
+                    selectedKeys = ThumbClusterConfig.common.thumbKeys
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                Button(l.thumbClusterConfigPresetExtended) {
+                    selectedKeys = ThumbClusterConfig.extended.thumbKeys
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(ThumbClusterConfig.assignableKeys, id: \.self) { key in
+                    Toggle(key, isOn: Binding(
+                        get: { selectedKeys.contains(key) },
+                        set: { isOn in
+                            if isOn { selectedKeys.insert(key) } else { selectedKeys.remove(key) }
+                        }
+                    ))
+                    .toggleStyle(.checkbox)
+                }
+            }
+
+            Divider()
+
+            HStack {
+                Spacer()
+                Button(l.thumbClusterConfigDone) {
+                    let config = selectedKeys.isEmpty ? nil : ThumbClusterConfig(thumbKeys: selectedKeys)
+                    LayoutRegistry.shared.setThumbConfig(config)
+                    onChanged()
+                    showConfig = false
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.regular)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 360)
     }
 }

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -36,6 +36,8 @@ struct ChartsView: View {
     @State var appsSubTab: AppsSubTab = .apps
     /// Active sub-tab within the Ergonomics tab (Issue #273).
     @State var ergoSubTab: ErgoSubTab = .bigrams
+    /// Whether the thumb cluster config sheet is open (Issue #333).
+    @State var showThumbClusterConfig: Bool = false
     /// State object for the Key Swap Optimizer (Issue #235).
     @StateObject var optimizerState = OptimizerSimulatorState()
     /// Saved drill presets stored as JSON (Issue #278).

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -470,9 +470,9 @@ final class KeyCountStore {
 
             let layout = LayoutRegistry.shared
             if let prev = lastKeyName,
-               let prevFinger = layout.current.finger(for: prevPhysical ?? prev),
+               let prevFinger = layout.finger(for: prevPhysical ?? prev),
                let prevHand   = layout.hand(for: prevPhysical ?? prev),
-               let curFinger  = layout.current.finger(for: physicalKey),
+               let curFinger  = layout.finger(for: physicalKey),
                let curHand    = layout.hand(for: physicalKey) {
 
                 store.ergonomics.totalBigramCount += 1
@@ -567,9 +567,9 @@ final class KeyCountStore {
                 // Issue #236: accumulate per-layer ergonomic deltas using the physical base key.
                 // prevPhysical was captured before lastKeyName/lastPhysicalKeyName were updated.
                 if let prevPhys = prevPhysical,
-                   let pFinger = layout.current.finger(for: prevPhys),
+                   let pFinger = layout.finger(for: prevPhys),
                    let pHand   = layout.hand(for: prevPhys),
-                   let cFinger = layout.current.finger(for: physicalKey),
+                   let cFinger = layout.finger(for: physicalKey),
                    let cHand   = layout.hand(for: physicalKey) {
                     let sf = (pFinger == cFinger && pHand == cHand)
                     let ha = (pHand != cHand)

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1928,6 +1928,45 @@ final class L10n {
         }
     }
 
+    // MARK: - Thumb Cluster Config (Issue #333)
+
+    var thumbClusterConfigTitle: String {
+        ja("親指クラスター設定", en: "Thumb Cluster Config")
+    }
+
+    var thumbClusterConfigHelp: String {
+        ja("DIYキーボードで親指クラスターに割り当てたキーを選択してください。選択したキーはすべてのエルゴノミクス分析で親指として扱われます。",
+           en: "Select keys that are physically on your thumb cluster. These keys will be treated as thumb-assigned in all ergonomic analysis.")
+    }
+
+    var thumbClusterConfigNone: String {
+        ja("親指クラスターキーなし (標準配列)", en: "No thumb cluster keys (standard layout)")
+    }
+
+    var thumbClusterConfigActive: String {
+        ja("親指クラスター: ", en: "Thumb cluster: ")
+    }
+
+    var thumbClusterConfigDone: String {
+        ja("完了", en: "Done")
+    }
+
+    var thumbClusterConfigPresetCommon: String {
+        ja("基本 (Delete + Return)", en: "Common (Delete + Return)")
+    }
+
+    var thumbClusterConfigPresetExtended: String {
+        ja("拡張 (Delete, Return, Tab, Escape, CapsLock)", en: "Extended (Delete, Return, Tab, Escape, CapsLock)")
+    }
+
+    var thumbClusterConfigPresetNone: String {
+        ja("なし", en: "None")
+    }
+
+    var thumbClusterConfigPresetLabel: String {
+        ja("プリセット", en: "Preset")
+    }
+
     // MARK: - Thumb Optimization (Issue #208)
 
     var handLeft:  String { ja("左", en: "Left") }

--- a/Sources/KeyLensCore/ErgonomicProfile.swift
+++ b/Sources/KeyLensCore/ErgonomicProfile.swift
@@ -14,23 +14,29 @@ public struct ErgonomicProfile: Equatable {
     
     /// Optional hand mapping overrides (for split keyboards).
     public let splitConfig: SplitKeyboardConfig?
-    
+
+    /// Optional finger overrides for thumb cluster keys on DIY keyboards.
+    public let thumbConfig: ThumbClusterConfig?
+
     public init(
         name: String,
         layout: any KeyboardLayout = ANSILayout(),
         fingerWeights: FingerLoadWeight = .default,
-        splitConfig: SplitKeyboardConfig? = nil
+        splitConfig: SplitKeyboardConfig? = nil,
+        thumbConfig: ThumbClusterConfig? = nil
     ) {
         self.name = name
         self.layout = layout
         self.fingerWeights = fingerWeights
         self.splitConfig = splitConfig
+        self.thumbConfig = thumbConfig
     }
-    
+
     public static func == (lhs: ErgonomicProfile, rhs: ErgonomicProfile) -> Bool {
         return lhs.name == rhs.name &&
                lhs.fingerWeights == rhs.fingerWeights &&
                lhs.splitConfig == rhs.splitConfig &&
+               lhs.thumbConfig == rhs.thumbConfig &&
                lhs.layout.name == rhs.layout.name
     }
 }

--- a/Sources/KeyLensCore/ErgonomicSnapshot.swift
+++ b/Sources/KeyLensCore/ErgonomicSnapshot.swift
@@ -160,8 +160,8 @@ public struct ErgonomicSnapshot: Equatable {
 
             totalPairs += count
 
-            guard let f1 = layout.current.finger(for: k1),
-                  let f2 = layout.current.finger(for: k2) else { continue }
+            guard let f1 = layout.finger(for: k1),
+                  let f2 = layout.finger(for: k2) else { continue }
 
             let h1 = layout.hand(for: k1)
             let h2 = layout.hand(for: k2)

--- a/Sources/KeyLensCore/KeyboardLayout.swift
+++ b/Sources/KeyLensCore/KeyboardLayout.swift
@@ -388,6 +388,43 @@ public struct SplitKeyboardConfig: Equatable {
     }
 }
 
+// MARK: - ThumbClusterConfig
+
+/// Declares which keys are physically on the thumb cluster of a custom keyboard.
+///
+/// On DIY keyboards (e.g. Corne, Moonlander), non-standard keys such as Backspace,
+/// Enter, and Delete are often moved to thumb-reachable positions. Configuring this
+/// tells KeyLens to treat those keys as thumb-assigned throughout all ergonomic analysis.
+public struct ThumbClusterConfig: Equatable {
+    /// Key names explicitly assigned to thumb. Must match KeyboardMonitor key name strings.
+    public let thumbKeys: Set<String>
+
+    public init(thumbKeys: Set<String> = []) {
+        self.thumbKeys = thumbKeys
+    }
+
+    /// Returns .thumb if keyName is in the thumb set, nil otherwise.
+    public func finger(for keyName: String) -> Finger? {
+        thumbKeys.contains(keyName) ? .thumb : nil
+    }
+
+    public var isEmpty: Bool { thumbKeys.isEmpty }
+
+    /// Keys that can reasonably be reassigned to a thumb cluster.
+    public static let assignableKeys: [String] = [
+        "Delete", "Return", "Tab", "Escape", "CapsLock",
+        "⌃Ctrl", "⇧Shift", "⌦FwdDel", "Enter(Num)"
+    ]
+
+    /// Preset: Backspace + Enter on thumb (common minimal cluster).
+    public static let common = ThumbClusterConfig(thumbKeys: ["Delete", "Return"])
+
+    /// Preset: common + Tab, Escape, CapsLock (extended cluster).
+    public static let extended = ThumbClusterConfig(
+        thumbKeys: ["Delete", "Return", "Tab", "Escape", "CapsLock"]
+    )
+}
+
 // MARK: - LayoutRegistry
 
 /// Holds the active keyboard layout and optional split configuration.
@@ -429,11 +466,33 @@ public final class LayoutRegistry {
         activeProfile.splitConfig?.hand(for: keyName) ?? activeProfile.layout.hand(for: keyName)
     }
 
+    /// Returns the finger for a key name, respecting ThumbClusterConfig overrides.
+    /// ThumbClusterConfig が設定されている場合はそれを優先する。
+    public func finger(for keyName: String) -> Finger? {
+        if let override = activeProfile.thumbConfig?.finger(for: keyName) { return override }
+        return activeProfile.layout.finger(for: keyName)
+    }
+
     /// Returns the load weight for the finger assigned to a key name, or nil if the key is unknown.
     /// キー名からその指の負荷重みを返す。未知のキーは nil。
     public func loadWeight(for keyName: String) -> Double? {
-        guard let finger = activeProfile.layout.finger(for: keyName) else { return nil }
-        return activeProfile.fingerWeights.weight(for: finger)
+        guard let f = finger(for: keyName) else { return nil }
+        return activeProfile.fingerWeights.weight(for: f)
+    }
+
+    /// Updates the thumb cluster configuration and persists it to UserDefaults.
+    /// 親指クラスター設定を更新し UserDefaults に永続化する。
+    public func setThumbConfig(_ config: ThumbClusterConfig?) {
+        let effective = config?.isEmpty == true ? nil : config
+        activeProfile = ErgonomicProfile(
+            name: activeProfile.name,
+            layout: activeProfile.layout,
+            fingerWeights: activeProfile.fingerWeights,
+            splitConfig: activeProfile.splitConfig,
+            thumbConfig: effective
+        )
+        let keys = Array(effective?.thumbKeys ?? [])
+        UserDefaults.standard.set(keys, forKey: Self.thumbConfigDefaultsKey)
     }
 
     // Deprecated properties — kept for backward compatibility if needed, but redirects to activeProfile
@@ -461,8 +520,8 @@ public final class LayoutRegistry {
 
         // Both keys must be on the same hand and use the same finger.
         // 同じ手・同じ指でなければ同指ビグラムではない。
-        guard let finger1 = activeProfile.layout.finger(for: k1),
-              let finger2 = activeProfile.layout.finger(for: k2),
+        guard let finger1 = finger(for: k1),
+              let finger2 = finger(for: k2),
               finger1 == finger2,
               let hand1 = hand(for: k1),
               let hand2 = hand(for: k2),
@@ -498,15 +557,34 @@ public final class LayoutRegistry {
     /// UserDefaults key for persisting the last resolved profile name.
     private static let profileDefaultsKey = "layoutRegistryProfileName"
 
+    /// UserDefaults key for persisting the thumb cluster key set.
+    private static let thumbConfigDefaultsKey = "layoutRegistryThumbKeys"
+
     /// Internal designated initialiser. Restores the last persisted profile if available.
     /// シングルトンは `.shared`、シミュレーション用は `forSimulation` を使うこと。
     init() {
+        var profile = ErgonomicProfile.standard
+
         if let saved = UserDefaults.standard.string(forKey: Self.profileDefaultsKey) {
             let known: [ErgonomicProfile] = [.standard, .splitErgo]
             if let match = known.first(where: { $0.name == saved }) {
-                activeProfile = match
+                profile = match
             }
         }
+
+        if let savedKeys = UserDefaults.standard.array(forKey: Self.thumbConfigDefaultsKey) as? [String],
+           !savedKeys.isEmpty {
+            let config = ThumbClusterConfig(thumbKeys: Set(savedKeys))
+            profile = ErgonomicProfile(
+                name: profile.name,
+                layout: profile.layout,
+                fingerWeights: profile.fingerWeights,
+                splitConfig: profile.splitConfig,
+                thumbConfig: config
+            )
+        }
+
+        activeProfile = profile
     }
 
     // MARK: - Simulation factory

--- a/Sources/KeyLensCore/ThumbEfficiencyCalculator.swift
+++ b/Sources/KeyLensCore/ThumbEfficiencyCalculator.swift
@@ -72,7 +72,7 @@ public struct ThumbEfficiencyCalculator: Equatable {
 
         for (key, count) in counts {
             totalCount += count
-            if layout.current.finger(for: key) == .thumb {
+            if layout.finger(for: key) == .thumb {
                 thumbCount += count
             }
         }

--- a/Sources/KeyLensCore/ThumbImbalanceDetector.swift
+++ b/Sources/KeyLensCore/ThumbImbalanceDetector.swift
@@ -69,7 +69,7 @@ public struct ThumbImbalanceDetector: Equatable {
         var right = 0
 
         for (key, count) in counts {
-            guard layout.current.finger(for: key) == .thumb else { continue }
+            guard layout.finger(for: key) == .thumb else { continue }
             switch layout.hand(for: key) {
             case .left:  left  += count
             case .right: right += count

--- a/Sources/KeyLensCore/ThumbRecommendationEngine.swift
+++ b/Sources/KeyLensCore/ThumbRecommendationEngine.swift
@@ -135,7 +135,7 @@ public struct ThumbRecommendationEngine {
         var leftThumbCount  = 0
         var rightThumbCount = 0
         for (key, count) in counts {
-            guard layout.current.finger(for: key) == .thumb else { continue }
+            guard layout.finger(for: key) == .thumb else { continue }
             switch layout.hand(for: key) {
             case .left:  leftThumbCount  += count
             case .right: rightThumbCount += count
@@ -158,7 +158,7 @@ public struct ThumbRecommendationEngine {
         let candidates: [Candidate] = counts.compactMap { key, count -> Candidate? in
             guard count > 0 else { return nil }
             guard !constraints.fixedKeys.contains(key) else { return nil }
-            guard let finger = layout.current.finger(for: key) else { return nil }
+            guard let finger = layout.finger(for: key) else { return nil }
             guard finger != .thumb else { return nil }  // already a thumb key
 
             let w = fingerWeights.weight(for: finger)


### PR DESCRIPTION
## Summary

- Adds `ThumbClusterConfig` — a `Set<String>` of key names that are physically on the user's thumb cluster, overriding the default ANSI finger assignment throughout all ergonomic analysis
- `LayoutRegistry.finger(for:)` checks thumb config first (O(1) lookup, no hot-path impact)
- Persisted to `UserDefaults` so config survives restarts
- Settings UI in Ergonomics → Tips tab: chip display of current config + sheet with per-key toggles and presets

## Changes

- `ThumbClusterConfig` struct with `assignableKeys`, `common`, and `extended` presets
- `ErgonomicProfile.thumbConfig` optional field
- `LayoutRegistry.finger(for:)` new method + `setThumbConfig(_:)` + UserDefaults persistence
- Updated callers: `KeyCountStore`, `ThumbImbalanceDetector`, `ThumbEfficiencyCalculator`, `ThumbRecommendationEngine`, `ErgonomicSnapshot`, `sameFingerPenalty`, `loadWeight`
- L10n strings (EN + JA)
- `ThumbClusterSettingsView` in Ergonomics → Tips tab

## Test plan

- [ ] Launch app, open Charts → Ergonomics → Tips
- [ ] Verify "No thumb cluster keys (standard layout)" appears by default
- [ ] Tap "Thumb Cluster Config", enable Delete and Return, tap Done
- [ ] Verify chips appear in the header row
- [ ] Relaunch app — config should persist
- [ ] Enable common preset, verify same-finger rate changes in Bigrams tab (Delete/Return now .thumb, can't same-finger with pinky keys)
- [ ] Verify zero build warnings

Closes #333