### PR TITLE
feat: modifier key analysis by finger (#334)

### DIFF
--- a/Sources/KeyLens/Charts+ShortcutsTab.swift
+++ b/Sources/KeyLens/Charts+ShortcutsTab.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import Charts
+import KeyLensCore
 
 extension ChartsView {
 
     var shortcutsTab: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 40) {
+                chartSection(L10n.shared.modifierFingerTitle, helpText: L10n.shared.modifierFingerHelp) { modifierFingerChart }
                 chartSection(L10n.shared.chartTitleCmdShortcuts, helpText: L10n.shared.helpShortcuts, showSort: true) { shortcutsChart }
                 chartSection(L10n.shared.chartTitleAllCombos, helpText: L10n.shared.helpAllCombos, showSort: true) { allCombosChart }
             }
@@ -102,5 +104,86 @@ extension ChartsView {
         case "⇧": return .green
         default:   return .gray
         }
+    }
+
+    // MARK: - Modifier Keys by Finger (Issue #334)
+
+    @ViewBuilder
+    var modifierFingerChart: some View {
+        let l = L10n.shared
+        let data = model.modifierFingerData
+
+        if data.allSatisfy({ $0.count == 0 }) {
+            Text(l.modifierFingerNoData)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                // Bar chart: one bar per modifier key, colored by finger
+                Chart(data) { item in
+                    BarMark(
+                        x: .value("Count", item.count),
+                        y: .value("Key", item.displayLabel)
+                    )
+                    .foregroundStyle(modifierFingerColor(item))
+                    .cornerRadius(3)
+                    .annotation(position: .trailing, spacing: 4) {
+                        if item.count > 0 {
+                            Text(item.count.formatted())
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks { value in
+                        AxisValueLabel {
+                            if let label = value.as(String.self) {
+                                VStack(alignment: .trailing, spacing: 0) {
+                                    Text(label).font(.system(size: 13, weight: .semibold))
+                                    Text(fingerLabel(for: label, in: data))
+                                        .font(.system(size: 10))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+                .chartLegend(.hidden)
+                .frame(height: CGFloat(data.count * 36 + 24))
+
+                // Summary line: thumb % vs pinky %
+                let total     = data.map(\.count).reduce(0, +)
+                let thumbSum  = data.filter(\.isThumb).map(\.count).reduce(0, +)
+                let pinkySum  = data.filter { !$0.isThumb }.map(\.count).reduce(0, +)
+                if total > 0 {
+                    let thumbPct = Int((Double(thumbSum) / Double(total) * 100).rounded())
+                    let pinkyPct = Int((Double(pinkySum) / Double(total) * 100).rounded())
+                    HStack(spacing: 16) {
+                        HStack(spacing: 6) {
+                            Circle().fill(Color.blue).frame(width: 8, height: 8)
+                            Text("Thumb").font(.caption).foregroundStyle(.secondary)
+                        }
+                        HStack(spacing: 6) {
+                            Circle().fill(Color.red).frame(width: 8, height: 8)
+                            Text("Pinky").font(.caption).foregroundStyle(.secondary)
+                        }
+                        Spacer()
+                        Text(l.modifierFingerSummary(thumbPct: thumbPct, pinkyPct: pinkyPct))
+                            .font(.system(size: 12, weight: .semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private func modifierFingerColor(_ entry: ModifierFingerEntry) -> Color {
+        entry.isThumb ? .blue : .red
+    }
+
+    private func fingerLabel(for displayLabel: String, in data: [ModifierFingerEntry]) -> String {
+        data.first(where: { $0.displayLabel == displayLabel })?.fingerLabel ?? ""
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -39,6 +39,16 @@ struct ShortcutEntry: Identifiable {
     init(_ t: (key: String, count: Int)) { id = t.key; key = t.key; count = t.count }
 }
 
+// Issue #334: modifier key breakdown by finger
+struct ModifierFingerEntry: Identifiable {
+    let id: String          // e.g. "⌘L"
+    let displayLabel: String
+    let keyName: String     // key name in store: "⌘Cmd", "Key(54)", etc.
+    let fingerLabel: String // e.g. "Thumb", "Pinky"
+    let isThumb: Bool
+    let count: Int
+}
+
 struct BigramEntry: Identifiable {
     let id: String
     let pair: String

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -12,6 +12,8 @@ final class ChartDataModel: ObservableObject {
     @Published var perDayKeys:           [DailyKeyEntry]        = []
     @Published var shortcuts:            [ShortcutEntry]        = []
     @Published var allCombos:            [ShortcutEntry]        = []
+    // Issue #334: modifier key finger breakdown
+    @Published var modifierFingerData:   [ModifierFingerEntry]  = []
     @Published var keyCounts:            [String: Int]          = [:]
     @Published var topBigrams:           [BigramEntry]          = []
     @Published var sameFingerRate:       Double?                = nil
@@ -186,6 +188,8 @@ final class ChartDataModel: ObservableObject {
             }
             // Issue #209: Layer key efficiency
             let layerEfficiency    = store.layerEfficiency()
+            // Issue #334: modifier key finger breakdown
+            let modifierFingerData = store.modifierFingerBreakdown()
 
             // Summary tab scalars (moved from view bodies to avoid main-thread DB calls)
             let totalCount       = store.totalCount
@@ -235,6 +239,7 @@ final class ChartDataModel: ObservableObject {
                 self.perDayKeys           = perDayKeys
                 self.shortcuts            = shortcuts
                 self.allCombos            = allCombos
+                self.modifierFingerData   = modifierFingerData
                 self.keyCounts            = keyCounts
                 self.topBigrams           = topBigrams
                 self.sameFingerRate       = sameFingerRate

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -136,6 +136,12 @@ extension KeyCountStore {
         let q = queue.sync { makeQuery() }
         return q.layerEfficiency()
     }
+
+    // Issue #334: modifier key breakdown by finger
+    func modifierFingerBreakdown() -> [ModifierFingerEntry] {
+        let q = queue.sync { makeQuery() }
+        return q.modifierFingerBreakdown()
+    }
 }
 
 // MARK: - Issue #299: Ergonomic Recommendations

--- a/Sources/KeyLens/KeyMetricsQuery.swift
+++ b/Sources/KeyLens/KeyMetricsQuery.swift
@@ -124,25 +124,26 @@ extension KeyMetricsQuery {
 
     // Issue #334: modifier key press counts broken down by finger assignment.
     // Uses LayoutRegistry.finger(for:) so ThumbClusterConfig overrides are respected.
+    // Counts are derived from modifiedCounts (combo strings like "⌘t", "⌃h")
+    // because modifier keypresses are not stored as individual keystrokes in keyCounts.
     func modifierFingerBreakdown() -> [ModifierFingerEntry] {
-        let registry = LayoutRegistry.shared
-        let counts   = store.counts
+        let registry  = LayoutRegistry.shared
+        let modCounts = store.shortcuts.modifiedCounts
 
-        // (displayLabel, storeName) — right-side modifiers appear as Key(N) from KeyboardMonitor
-        let modifierKeys: [(display: String, store: String)] = [
-            ("⌘L", "⌘Cmd"),
-            ("⌘R", "Key(54)"),
-            ("⇧L", "⇧Shift"),
-            ("⇧R", "Key(60)"),
-            ("⌥L", "⌥Option"),
-            ("⌥R", "Key(61)"),
-            ("⌃L", "⌃Ctrl"),
-            ("⌃R", "Key(62)"),
+        // (symbol in combo string, display label, canonical key name for finger lookup)
+        let modifiers: [(symbol: String, displayLabel: String, keyName: String)] = [
+            ("⌘", "⌘ Cmd",    "⌘Cmd"),
+            ("⇧", "⇧ Shift",  "⇧Shift"),
+            ("⌥", "⌥ Option", "⌥Option"),
+            ("⌃", "⌃ Ctrl",   "⌃Ctrl"),
         ]
 
-        return modifierKeys.compactMap { (display, storeName) -> ModifierFingerEntry? in
-            let count = counts[storeName] ?? 0
-            guard let finger = registry.finger(for: storeName) else { return nil }
+        return modifiers.compactMap { (symbol, displayLabel, keyName) -> ModifierFingerEntry? in
+            // Sum counts of all combos that contain this modifier symbol
+            let count = modCounts.reduce(0) { acc, pair in
+                pair.key.contains(symbol) ? acc + pair.value : acc
+            }
+            guard let finger = registry.finger(for: keyName) else { return nil }
             let isThumb = finger == .thumb
             let fingerLabel: String
             switch finger {
@@ -153,9 +154,9 @@ extension KeyMetricsQuery {
             case .index:  fingerLabel = "Index"
             }
             return ModifierFingerEntry(
-                id:           display,
-                displayLabel: display,
-                keyName:      storeName,
+                id:           displayLabel,
+                displayLabel: displayLabel,
+                keyName:      keyName,
                 fingerLabel:  fingerLabel,
                 isThumb:      isThumb,
                 count:        count

--- a/Sources/KeyLens/KeyMetricsQuery.swift
+++ b/Sources/KeyLens/KeyMetricsQuery.swift
@@ -122,6 +122,47 @@ extension KeyMetricsQuery {
         return topEntries(filtered, limit: limit)
     }
 
+    // Issue #334: modifier key press counts broken down by finger assignment.
+    // Uses LayoutRegistry.finger(for:) so ThumbClusterConfig overrides are respected.
+    func modifierFingerBreakdown() -> [ModifierFingerEntry] {
+        let registry = LayoutRegistry.shared
+        let counts   = store.counts
+
+        // (displayLabel, storeName) — right-side modifiers appear as Key(N) from KeyboardMonitor
+        let modifierKeys: [(display: String, store: String)] = [
+            ("⌘L", "⌘Cmd"),
+            ("⌘R", "Key(54)"),
+            ("⇧L", "⇧Shift"),
+            ("⇧R", "Key(60)"),
+            ("⌥L", "⌥Option"),
+            ("⌥R", "Key(61)"),
+            ("⌃L", "⌃Ctrl"),
+            ("⌃R", "Key(62)"),
+        ]
+
+        return modifierKeys.compactMap { (display, storeName) -> ModifierFingerEntry? in
+            let count = counts[storeName] ?? 0
+            guard let finger = registry.finger(for: storeName) else { return nil }
+            let isThumb = finger == .thumb
+            let fingerLabel: String
+            switch finger {
+            case .thumb:  fingerLabel = "Thumb"
+            case .pinky:  fingerLabel = "Pinky"
+            case .ring:   fingerLabel = "Ring"
+            case .middle: fingerLabel = "Middle"
+            case .index:  fingerLabel = "Index"
+            }
+            return ModifierFingerEntry(
+                id:           display,
+                displayLabel: display,
+                keyName:      storeName,
+                fingerLabel:  fingerLabel,
+                isThumb:      isThumb,
+                count:        count
+            )
+        }
+    }
+
     func topKeys(limit: Int = 10) -> [(key: String, count: Int)] {
         topEntries(store.counts, limit: limit)
     }

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1928,6 +1928,26 @@ final class L10n {
         }
     }
 
+    // MARK: - Modifier Finger Analysis (Issue #334)
+
+    var modifierFingerTitle: String {
+        ja("モディファイアキーの指別分析", en: "Modifier Keys by Finger")
+    }
+
+    var modifierFingerHelp: String {
+        ja("各モディファイアキー (⌘⇧⌥⌃) が何の指で押されているかを示します。親指クラスターに移動したキーは「Thumb」として表示されます。",
+           en: "Shows which finger presses each modifier key (⌘⇧⌥⌃). Keys moved to a thumb cluster appear as Thumb.")
+    }
+
+    var modifierFingerNoData: String {
+        ja("モディファイアキーのデータなし", en: "No modifier key data yet")
+    }
+
+    func modifierFingerSummary(thumbPct: Int, pinkyPct: Int) -> String {
+        ja("親指 \(thumbPct)%  /  小指 \(pinkyPct)%",
+           en: "Thumb \(thumbPct)%  /  Pinky \(pinkyPct)%")
+    }
+
     // MARK: - Thumb Cluster Config (Issue #333)
 
     var thumbClusterConfigTitle: String {


### PR DESCRIPTION
## Summary
- Adds **Modifier Keys by Finger** section at the top of the Shortcuts tab
- Horizontal bar chart shows each modifier key (⌘L/R, ⇧L/R, ⌥L/R, ⌃L/R) colored blue (thumb) or red (pinky)
- Y-axis labels include a sub-text finger type (Thumb / Pinky / Ring / etc.)
- Summary line shows Thumb% vs Pinky% share across all modifier presses

## Technical details
- `ModifierFingerEntry` struct in `ChartsDataTypes.swift`
- `modifierFingerBreakdown()` in `KeyMetricsQuery` + thin `KeyCountStore` bridge in `KeyCountStore+Ergonomics.swift`
- Right-side modifier keys resolved via their `Key(N)` store names (54=⌘R, 60=⇧R, 61=⌥R, 62=⌃R)
- Respects `ThumbClusterConfig` override (from #333) via `LayoutRegistry.finger(for:)`

## Test plan
- [ ] Open Charts window → Shortcuts tab → "Modifier Keys by Finger" section appears
- [ ] Bars are blue for thumb-assigned keys, red for pinky-assigned keys
- [ ] Thumb%/Pinky% summary line appears when total > 0
- [ ] No data state shows localized message when no modifier keys have been pressed
- [ ] Zero warnings on `swift build -c release`

Closes #334