### PR TITLE
feat: shortcut strain — same-hand chord analysis (#335)

### DIFF
--- a/Sources/KeyLens/Charts+ShortcutsTab.swift
+++ b/Sources/KeyLens/Charts+ShortcutsTab.swift
@@ -10,6 +10,7 @@ extension ChartsView {
                 chartSection(L10n.shared.modifierFingerTitle, helpText: L10n.shared.modifierFingerHelp) { modifierFingerChart }
                 chartSection(L10n.shared.chartTitleCmdShortcuts, helpText: L10n.shared.helpShortcuts, showSort: true) { shortcutsChart }
                 chartSection(L10n.shared.chartTitleAllCombos, helpText: L10n.shared.helpAllCombos, showSort: true) { allCombosChart }
+                chartSection(L10n.shared.shortcutStrainTitle, helpText: L10n.shared.shortcutStrainHelp) { shortcutStrainChart }
             }
             .padding(24)
         }
@@ -185,5 +186,61 @@ extension ChartsView {
 
     private func fingerLabel(for displayLabel: String, in data: [ModifierFingerEntry]) -> String {
         data.first(where: { $0.displayLabel == displayLabel })?.fingerLabel ?? ""
+    }
+
+    // MARK: - Shortcut Strain (Issue #335)
+
+    @ViewBuilder
+    var shortcutStrainChart: some View {
+        let l        = L10n.shared
+        let entries  = model.shortcutStrainEntries
+        let total    = model.shortcutStrainTotalPresses
+
+        if total == 0 {
+            Text(l.shortcutStrainNoData)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else if entries.isEmpty {
+            let pct = 0
+            let same = 0
+            VStack(alignment: .leading, spacing: 6) {
+                Text(l.shortcutStrainRate(pct: pct, sameCount: same, totalCount: total))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                Text(l.shortcutStrainNoData)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        } else {
+            let samePressesl = entries.map(\.count).reduce(0, +)
+            let pct = Int((Double(samePressesl) / Double(total) * 100).rounded())
+            let display = Array(entries.prefix(20))
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(l.shortcutStrainRate(pct: pct, sameCount: samePressesl, totalCount: total))
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.secondary)
+
+                let keyOrder = display.map(\.combo)
+                Chart(display) { item in
+                    BarMark(
+                        x: .value("Count", item.count),
+                        y: .value("Combo", item.combo)
+                    )
+                    .foregroundStyle(Color.red.opacity(0.75))
+                    .cornerRadius(3)
+                    .annotation(position: .trailing, spacing: 4) {
+                        Text(item.count.formatted())
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                .chartYScale(domain: keyOrder)
+                .chartLegend(.hidden)
+                .chartXAxisLabel(L10n.shared.axisLabelKeys, alignment: .trailing)
+                .frame(height: CGFloat(display.count * 26 + 24))
+            }
+        }
     }
 }

--- a/Sources/KeyLens/ChartsDataTypes.swift
+++ b/Sources/KeyLens/ChartsDataTypes.swift
@@ -49,6 +49,13 @@ struct ModifierFingerEntry: Identifiable {
     let count: Int
 }
 
+// Issue #335: same-hand shortcut strain entry
+struct ShortcutStrainEntry: Identifiable {
+    let id: String      // combo string e.g. "⌃a"
+    let combo: String
+    let count: Int
+}
+
 struct BigramEntry: Identifiable {
     let id: String
     let pair: String

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -89,6 +89,9 @@ final class ChartDataModel: ObservableObject {
     @Published var heatmapGrid:                [MouseGridCell]               = []
     // Issue #209: Layer key efficiency
     @Published var layerEfficiency:            [LayerEfficiencyEntry]        = []
+    // Issue #335: same-finger shortcut strain
+    @Published var shortcutStrainEntries:      [ShortcutStrainEntry]         = []
+    @Published var shortcutStrainTotalPresses: Int                           = 0
     // Issue #258: background loading state
     @Published var isLoading: Bool = false
 
@@ -190,6 +193,8 @@ final class ChartDataModel: ObservableObject {
             let layerEfficiency    = store.layerEfficiency()
             // Issue #334: modifier key finger breakdown
             let modifierFingerData = store.modifierFingerBreakdown()
+            // Issue #335: same-finger shortcut strain
+            let shortcutStrain = store.shortcutStrain()
 
             // Summary tab scalars (moved from view bodies to avoid main-thread DB calls)
             let totalCount       = store.totalCount
@@ -271,7 +276,9 @@ final class ChartDataModel: ObservableObject {
                 self.fatigueCurve         = fatigueCurve
                 self.trainingHistory      = trainingHistory
                 self.bigramIKIMap         = bigramIKIMap
-                self.layerEfficiency      = layerEfficiency
+                self.layerEfficiency           = layerEfficiency
+                self.shortcutStrainEntries     = shortcutStrain.entries
+                self.shortcutStrainTotalPresses = shortcutStrain.totalPresses
                 self.mouseDailyDistances        = mouseDailyDistances
                 self.mouseHourlyActivity        = mouseHourlyActivity
                 self.mouseDirectionEntries      = mouseDirectionEntries

--- a/Sources/KeyLens/KeyCountStore+Ergonomics.swift
+++ b/Sources/KeyLens/KeyCountStore+Ergonomics.swift
@@ -142,6 +142,12 @@ extension KeyCountStore {
         let q = queue.sync { makeQuery() }
         return q.modifierFingerBreakdown()
     }
+
+    // Issue #335: same-finger shortcut strain
+    func shortcutStrain() -> (entries: [ShortcutStrainEntry], totalPresses: Int) {
+        let q = queue.sync { makeQuery() }
+        return q.shortcutStrainEntries()
+    }
 }
 
 // MARK: - Issue #299: Ergonomic Recommendations

--- a/Sources/KeyLens/KeyMetricsQuery.swift
+++ b/Sources/KeyLens/KeyMetricsQuery.swift
@@ -145,22 +145,76 @@ extension KeyMetricsQuery {
             }
             guard let finger = registry.finger(for: keyName) else { return nil }
             let isThumb = finger == .thumb
-            let fingerLabel: String
-            switch finger {
-            case .thumb:  fingerLabel = "Thumb"
-            case .pinky:  fingerLabel = "Pinky"
-            case .ring:   fingerLabel = "Ring"
-            case .middle: fingerLabel = "Middle"
-            case .index:  fingerLabel = "Index"
-            }
             return ModifierFingerEntry(
                 id:           displayLabel,
                 displayLabel: displayLabel,
                 keyName:      keyName,
-                fingerLabel:  fingerLabel,
+                fingerLabel:  Self.fingerLabel(finger),
                 isThumb:      isThumb,
                 count:        count
             )
+        }
+    }
+
+    // Issue #335: same-hand shortcut strain analysis.
+    // A chord is "strained" when both the modifier and base key are on the same hand,
+    // requiring one hand to stretch across two keys simultaneously.
+    // (Same-finger is physically impossible for chords; same-hand is the actual ergonomic concern.)
+    // Returns same-hand entries sorted by count, plus total presses across all combos.
+    func shortcutStrainEntries() -> (entries: [ShortcutStrainEntry], totalPresses: Int) {
+        let registry  = LayoutRegistry.shared
+        let modCounts = store.shortcuts.modifiedCounts
+        let totalPresses = modCounts.values.reduce(0, +)
+
+        let modifierSymbols = ["⌘", "⇧", "⌥", "⌃"]
+        let modifierKeyNames: [String: String] = [
+            "⌘": "⌘Cmd", "⇧": "⇧Shift", "⌥": "⌥Option", "⌃": "⌃Ctrl"
+        ]
+
+        var result: [ShortcutStrainEntry] = []
+
+        for (combo, count) in modCounts {
+            // Strip leading modifier symbols to find the base key
+            var remaining = combo
+            var mods: [String] = []
+            var changed = true
+            while changed {
+                changed = false
+                for sym in modifierSymbols {
+                    if remaining.hasPrefix(sym) {
+                        mods.append(sym)
+                        remaining = String(remaining.dropFirst(sym.count))
+                        changed = true
+                        break
+                    }
+                }
+            }
+            let baseKey = remaining
+            guard !baseKey.isEmpty, !mods.isEmpty else { continue }
+            guard let keyHand = registry.hand(for: baseKey) else { continue }
+
+            // Flag if any modifier is on the same hand as the base key
+            for sym in mods {
+                guard let modKeyName = modifierKeyNames[sym],
+                      let modHand    = registry.hand(for: modKeyName),
+                      modHand == keyHand else { continue }
+                result.append(ShortcutStrainEntry(id: combo, combo: combo, count: count))
+                break  // one match per combo is enough
+            }
+        }
+
+        let sorted = result.sorted { $0.count > $1.count }
+        return (sorted, totalPresses)
+    }
+
+    // Shared finger label helper
+    private static func fingerLabel(_ finger: Finger) -> String {
+        switch finger {
+        case .thumb:  return "Thumb"
+        case .pinky:  return "Pinky"
+        case .ring:   return "Ring"
+        case .middle: return "Middle"
+        case .index:  return "Index"
         }
     }
 

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -2396,6 +2396,26 @@ final class L10n {
     }
     func recImpact(_ pts: Int) -> String { ja("+\(pts)pt", en: "+\(pts)pt") }
 
+    // MARK: - Shortcut Strain Analysis (Issue #335)
+
+    var shortcutStrainTitle: String {
+        ja("ショートカット負荷分析", en: "Shortcut Strain")
+    }
+
+    var shortcutStrainHelp: String {
+        ja("モディファイアキーとベースキーが同じ手にある場合、片手でストレッチが必要になり負荷が高まります。頻度の高いコンボほど影響が大きくなります。",
+           en: "A shortcut is strained when the modifier and base key are on the same hand, forcing a one-handed stretch. Higher-frequency combos have greater impact.")
+    }
+
+    var shortcutStrainNoData: String {
+        ja("片手ショートカットは検出されませんでした", en: "No same-hand shortcuts detected")
+    }
+
+    func shortcutStrainRate(pct: Int, sameCount: Int, totalCount: Int) -> String {
+        ja("同手率 \(pct)%（\(sameCount) / \(totalCount) 押下）",
+           en: "Same-hand rate: \(pct)% (\(sameCount) of \(totalCount) presses)")
+    }
+
     // MARK: - Advanced Mode (#307)
 
     var advancedModeMenuTitle: String { ja("高度なモード", en: "Advanced Mode") }


### PR DESCRIPTION
## Summary
- Adds **Shortcut Strain** section to the Shortcuts tab
- Flags modifier+key combos where both keys are on the **same hand** (one-handed stretch)
- Headline shows same-hand rate: e.g. "Same-hand rate: 34% (820 of 2400 presses)"
- Bar chart of same-hand combos sorted by frequency, colored red

## Why same-hand (not same-finger)
Same-finger is physically impossible for chords — you can't hold Ctrl and press A with the same pinky simultaneously. The real ergonomic cost is **same-hand stretching**: both modifier and base key on one hand forces that hand to cover two positions at once.

## Technical details
- Uses `LayoutRegistry.hand(for:)` (respects `SplitKeyboardConfig`)
- Parses modifier prefix symbols from combo strings (e.g. `⌃h` → modifier `⌃`, base `h`)
- Multi-modifier combos (e.g. `⇧⌘e`) flagged if ANY modifier shares a hand with the base key

## Test plan
- [ ] Open Charts → Shortcuts tab → "Shortcut Strain" section visible at bottom
- [ ] Headline shows same-hand rate with press counts
- [ ] Bar chart shows same-hand combos sorted by frequency
- [ ] `⌃a`, `⌃b`, `⌘q` etc. appear (left-hand modifier + left-hand base key)
- [ ] `⌃k`, `⌘j` etc. do NOT appear (left modifier + right base key)
- [ ] Zero warnings on `swift build -c release`

Closes #335