### PR TITLE
feat: map Key(N) keycodes to human-readable names (#341)

### DIFF
--- a/Sources/KeyLens/Charts+ShortcutsTab.swift
+++ b/Sources/KeyLens/Charts+ShortcutsTab.swift
@@ -21,13 +21,13 @@ extension ChartsView {
         if model.shortcuts.isEmpty {
             emptyState
         } else {
-            let keyOrder = model.shortcuts.map(\.key)
+            let keyOrder = model.shortcuts.map { KeyCodeName.display(for: $0.key) }
             let domain = sortDescending ? Array(keyOrder.reversed()) : keyOrder
 
             Chart(model.shortcuts) { item in
                 BarMark(
                     x: .value("Count", item.count),
-                    y: .value("Shortcut", item.key)
+                    y: .value("Shortcut", KeyCodeName.display(for: item.key))
                 )
                 .foregroundStyle(shortcutColor(item.key))
                 .cornerRadius(3)
@@ -59,14 +59,14 @@ extension ChartsView {
         if model.allCombos.isEmpty {
             emptyState
         } else {
-            let keyOrder = model.allCombos.map(\.key)
+            let keyOrder = model.allCombos.map { KeyCodeName.display(for: $0.key) }
             let domain = sortDescending ? Array(keyOrder.reversed()) : keyOrder
 
             VStack(alignment: .leading, spacing: 6) {
                 Chart(model.allCombos) { item in
                     BarMark(
                         x: .value("Count", item.count),
-                        y: .value("Combo", item.key)
+                        y: .value("Combo", KeyCodeName.display(for: item.key))
                     )
                     .foregroundStyle(comboColor(item.key))
                     .cornerRadius(3)
@@ -222,11 +222,11 @@ extension ChartsView {
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
 
-                let keyOrder = display.map(\.combo)
+                let keyOrder = display.map { KeyCodeName.display(for: $0.combo) }
                 Chart(display) { item in
                     BarMark(
                         x: .value("Count", item.count),
-                        y: .value("Combo", item.combo)
+                        y: .value("Combo", KeyCodeName.display(for: item.combo))
                     )
                     .foregroundStyle(Color.red.opacity(0.75))
                     .cornerRadius(3)

--- a/Sources/KeyLens/KeyCodeName.swift
+++ b/Sources/KeyLens/KeyCodeName.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// Maps Key(N) raw keycode strings to human-readable display names.
+/// Display-only — stored key names are never modified.
+///
+/// Usage:
+///   KeyCodeName.display(for: "⌘Key(119)")  // → "⌘End"
+///   KeyCodeName.display(for: "Key(102)")   // → "英数"
+enum KeyCodeName {
+
+    // kVK_* values from Carbon HIToolbox/Events.h
+    static let table: [UInt16: String] = [
+        // Navigation keys
+        115: "Home",
+        119: "End",
+        116: "PageUp",
+        121: "PageDown",
+        117: "⌦",       // Forward Delete
+        114: "Help",
+
+        // JIS IME keys
+        102: "英数",     // kVK_JIS_Eisu
+        104: "かな",     // kVK_JIS_Kana
+        93:  "¥",       // kVK_JIS_Yen
+
+        // Function keys
+        122: "F1",
+        120: "F2",
+        99:  "F3",
+        118: "F4",
+        96:  "F5",
+        97:  "F6",
+        98:  "F7",
+        100: "F8",
+        101: "F9",
+        109: "F10",
+        103: "F11",
+        111: "F12",
+        105: "F13",
+        107: "F14",
+        113: "F15",
+        106: "F16",
+
+        // Other unnamed keys
+        50:  "`",        // Grave / backtick
+        72:  "VolUp",
+        73:  "VolDown",
+        74:  "Mute",
+    ]
+
+    /// Replaces any Key(N) pattern in the string with a human-readable name.
+    /// Returns the original string unchanged if no Key(N) is found or the code is unknown.
+    static func display(for raw: String) -> String {
+        guard let range = raw.range(of: #"Key\(\d+\)"#, options: .regularExpression) else {
+            return raw
+        }
+        let keyStr = String(raw[range])
+        let numStr = keyStr.dropFirst(4).dropLast()
+        guard let code = UInt16(numStr), let name = table[code] else { return raw }
+        return raw.replacingCharacters(in: range, with: name)
+    }
+}


### PR DESCRIPTION
## Summary
- New `KeyCodeName.swift` with static keycode → display name table
- Replaces `Key(N)` patterns in chart labels at display time (stored names unchanged)
- Applied to Shortcuts, All Combos, and Shortcut Strain charts

## Key mappings added
- Navigation: Home, End, PageUp, PageDown, ⌦, Help
- JIS IME: 英数 (102), かな (104), ¥ (93)
- F1–F16
- Other: `` ` ``, VolUp, VolDown, Mute

Closes #341