### PR TITLE
fix: backup/restore targets keylens.db instead of counts.json

### DIFF
--- a/Sources/KeyLens/AppDelegate+Actions.swift
+++ b/Sources/KeyLens/AppDelegate+Actions.swift
@@ -375,15 +375,19 @@ extension AppDelegate {
 
         let panel = NSSavePanel()
         panel.title = L10n.shared.backupMenuItem
-        panel.nameFieldStringValue = "KeyLens-backup-\(tag).json"
-        panel.allowedContentTypes = [.json]
+        panel.nameFieldStringValue = "KeyLens-backup-\(tag).db"
+        panel.allowedContentTypes = [.init(filenameExtension: "db")!]
         panel.canCreateDirectories = true
 
         NSApp.activate(ignoringOtherApps: true)
         panel.begin { response in
             guard response == .OK, let dest = panel.url else { return }
-            let src = KeyCountStore.shared.saveURL
-            try? FileManager.default.copyItem(at: src, to: dest)
+            do {
+                try KeyCountStore.shared.exportSQLite(to: dest)
+                NSWorkspace.shared.selectFile(dest.path, inFileViewerRootedAtPath: "")
+            } catch {
+                KeyLens.log("Backup failed: \(error)")
+            }
         }
     }
 
@@ -401,20 +405,23 @@ extension AppDelegate {
 
         let panel = NSOpenPanel()
         panel.title = l.restoreMenuItem
-        panel.allowedContentTypes = [.json]
+        panel.allowedContentTypes = [.init(filenameExtension: "db")!]
         panel.allowsMultipleSelection = false
         panel.canChooseDirectories = false
 
         NSApp.activate(ignoringOtherApps: true)
         panel.begin { response in
             guard response == .OK, let src = panel.url else { return }
-            let dest = KeyCountStore.shared.saveURL
             do {
-                _ = try? FileManager.default.removeItem(at: dest)
-                try FileManager.default.copyItem(at: src, to: dest)
-                KeyCountStore.shared.reload()
+                try KeyCountStore.shared.restoreFromBackup(url: src)
             } catch {
                 KeyLens.log("Restore failed: \(error)")
+                DispatchQueue.main.async {
+                    let err = NSAlert()
+                    err.messageText = l.restoreFailedAlert
+                    err.informativeText = error.localizedDescription
+                    err.runModal()
+                }
             }
         }
     }

--- a/Sources/KeyLens/KeyCountStore+Export.swift
+++ b/Sources/KeyLens/KeyCountStore+Export.swift
@@ -86,4 +86,30 @@ extension KeyCountStore {
         let dest = try DatabaseQueue(path: url.path)
         try src.backup(to: dest)
     }
+
+    /// Replace live keylens.db with the given backup .db file and reload all in-memory state.
+    func restoreFromBackup(url: URL) throws {
+        flushSync()
+        var thrownError: Error?
+        queue.sync {
+            guard let db = dbQueue else { return }
+            let dest = URL(fileURLWithPath: db.path)
+            dbQueue = nil
+            do {
+                if FileManager.default.fileExists(atPath: dest.path) {
+                    try FileManager.default.removeItem(at: dest)
+                }
+                try FileManager.default.copyItem(at: url, to: dest)
+                dbQueue = try DatabaseQueue(path: dest.path)
+            } catch {
+                // Re-open original path so the app isn't left without a DB.
+                dbQueue = try? DatabaseQueue(path: dest.path)
+                thrownError = error
+                return
+            }
+            resetInMemoryStateLocked()
+        }
+        if let error = thrownError { throw error }
+        loadFromSQLite()
+    }
 }

--- a/Sources/KeyLens/KeyCountStore.swift
+++ b/Sources/KeyLens/KeyCountStore.swift
@@ -679,6 +679,14 @@ final class KeyCountStore {
         }
     }
 
+    /// Resets all in-memory state. Must be called from within `queue`.
+    func resetInMemoryStateLocked() {
+        store = CountData(startedAt: Date(), counts: [:])
+        pending = PendingStore()
+        _todayCount = 0
+        _todayCacheDate = todayKey
+    }
+
     /// Restores data from a backup URL produced by backupDBForUndo().
     /// Closes the current DB, overwrites the live file with the backup, and reloads in-memory state.
     func restoreFromUndo(url: URL) {
@@ -694,10 +702,7 @@ final class KeyCountStore {
             } catch {
                 return
             }
-            store = CountData(startedAt: Date(), counts: [:])
-            pending = PendingStore()
-            _todayCount = 0
-            _todayCacheDate = todayKey
+            resetInMemoryStateLocked()
         }
         loadFromSQLite()
     }

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -622,6 +622,10 @@ final class L10n {
         ja("復元", en: "Restore")
     }
 
+    var restoreFailedAlert: String {
+        ja("バックアップからの復元に失敗しました", en: "Failed to restore from backup")
+    }
+
     var copyDataMenuItem: String {
         ja("データをコピー", en: "Copy Data to Clipboard")
     }


### PR DESCRIPTION
## Summary

- `Save Backup…` now saves a `.db` file (GRDB backup of `keylens.db`) instead of copying the stale `counts.json`
- `Restore from Backup…` now accepts a `.db` file and replaces the live `keylens.db`, then reloads in-memory state
- Added `restoreFromBackup(url:)` in `KeyCountStore+Export.swift` using the same pattern as `restoreFromUndo`
- Added `resetInMemoryStateLocked()` helper in `KeyCountStore.swift` (also used to simplify `restoreFromUndo`)
- Added `restoreFailedAlert` L10n string for the error alert

Closes #356

## Test plan

- [ ] Save Backup… → produces `.db` file, Finder reveals it
- [ ] Restore from Backup… → accepts `.db`, data reloads correctly
- [ ] Restore with corrupt file → shows error alert
- [ ] Export SQLite… still works (unchanged path)