### PR TITLE
feat: make streak row in menu clickable — opens Charts to Sessions

### DIFF
--- a/Sources/KeyLens/AppDelegate+Actions.swift
+++ b/Sources/KeyLens/AppDelegate+Actions.swift
@@ -24,6 +24,12 @@ extension AppDelegate {
         ChartsWindowController.shared.showWindow()
     }
 
+    func showChartsAtSessions() {
+        UserDefaults.standard.set(ChartTab.typing.rawValue, forKey: UDKeys.selectedChartTab)
+        UserDefaults.standard.set(ActivitySubTab.volume.rawValue, forKey: UDKeys.selectedActivitySubTab)
+        ChartsWindowController.shared.showWindow()
+    }
+
     func toggleOverlay() {
         KeystrokeOverlayController.shared.isEnabled.toggle()
         objectWillChange.send()

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -25,7 +25,7 @@ struct ChartsView: View {
     /// Active sub-tab within the Live tab (Issue #271).
     @State var liveSubTab: LiveSubTab = .monitor
     /// Active sub-tab within the Activity tab (Issue #272).
-    @State var activitySubTab: ActivitySubTab = .speed
+    @AppStorage(UDKeys.selectedActivitySubTab) var activitySubTab: ActivitySubTab = .speed
     /// Active sub-tab within the Keyboard tab (Issue #277).
     @State var keyboardSubTab: KeyboardSubTab = .heatmap
     /// Active sub-tab within the Training tab (Issue #276).

--- a/Sources/KeyLens/MenuView.swift
+++ b/Sources/KeyLens/MenuView.swift
@@ -85,9 +85,13 @@ struct MenuView: View {
                     let streak = KeyCountStore.shared.currentStreak()
                     let today  = KeyCountStore.shared.todayCount
                     if goal > 0 {
-                        infoRow(l.streakCompact(streak: streak, today: today, goal: goal))
+                        menuRow(l.streakCompact(streak: streak, today: today, goal: goal)) {
+                            appDelegate.showChartsAtSessions()
+                        }
                     } else {
-                        infoRow(l.streakNoGoalHint)
+                        menuRow(l.streakNoGoalHint) {
+                            appDelegate.showChartsAtSessions()
+                        }
                     }
                 case .shortcutEfficiency:
                     if let pct = KeyCountStore.shared.shortcutEfficiencyToday() {

--- a/Sources/KeyLens/UserDefaultsKeys.swift
+++ b/Sources/KeyLens/UserDefaultsKeys.swift
@@ -20,6 +20,7 @@ enum UDKeys {
     static let milestoneInterval           = "milestoneInterval"
     static let perfProfilingEnabled        = "perfProfilingEnabled"
     static let selectedChartTab            = "selectedChartTab"
+    static let selectedActivitySubTab      = "selectedActivitySubTab"
     static let selectedMouseSubTab         = "selectedMouseSubTab"
     static let speedometerSize             = "speedometerSize"
     static let thumbOptimizationEnabled    = "thumbOptimizationEnabled"


### PR DESCRIPTION
## Summary

- The streak widget row ("🔥 3-day…") in the pull-down menu is now clickable
- Clicking it opens the Charts window directly on the **Typing → Activity → Volume** subtab where the Sessions chart and streak badge live
- Converted `activitySubTab` from `@State` to `@AppStorage` so it can be set programmatically (same pattern as `mouseSubTab`)
- Added `showChartsAtSessions()` in `AppDelegate+Actions.swift` (same pattern as `showMouseDistanceChart()`)

## Test plan

- [ ] Click streak row → Charts opens on Typing tab, Activity subtab = Volume, Sessions chart visible
- [ ] Click streak row when no goal set (`streakNoGoalHint`) → same navigation
- [ ] Charts tab/subtab selection still persists between opens normally

Closes #359