### PR TITLE
feat: merge Today + Mouse Distance into single todaySummary widget

### DIFF
--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -60,9 +60,9 @@ final class L10n {
         let keysStr = keys.formatted()
         if let pts = mousePts {
             let dist = mouseDistanceString(pts)
-            return ja("本日: \(keysStr) · \(dist)", en: "Today: \(keysStr) · \(dist)")
+            return ja("本日: \(keysStr) keys, \(dist)", en: "Today: \(keysStr) keys, \(dist)")
         }
-        return ja("本日: \(keysStr)", en: "Today: \(keysStr)")
+        return ja("本日: \(keysStr) keys", en: "Today: \(keysStr) keys")
     }
 
     var noInput: String {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -56,6 +56,15 @@ final class L10n {
         ja("本日: %@", en: "Today: %@")
     }
 
+    func todaySummaryDisplay(keys: Int, mousePts: Double?) -> String {
+        let keysStr = keys.formatted()
+        if let pts = mousePts {
+            let dist = mouseDistanceString(pts)
+            return ja("本日: \(keysStr) · \(dist)", en: "Today: \(keysStr) · \(dist)")
+        }
+        return ja("本日: \(keysStr)", en: "Today: \(keysStr)")
+    }
+
     var noInput: String {
         ja("（まだ入力なし）", en: "(no input yet)")
     }
@@ -1461,13 +1470,12 @@ final class L10n {
     func widgetDisplayName(_ widget: MenuWidget) -> String {
         switch widget {
         case .recordingSince: return ja("記録開始日", en: "Recording Since")
-        case .todayTotal:     return ja("本日", en: "Today")
+        case .todaySummary:   return ja("本日サマリー", en: "Today Summary")
         case .avgInterval:    return ja("平均打鍵間隔", en: "Avg Interval")
         case .estimatedWPM:   return ja("WPM", en: "WPM")
         case .miniChart:      return ja("直近7日グラフ", en: "Last 7 Days Chart")
         case .streak:                     return ja("ストリーク", en: "Streak")
         case .shortcutEfficiency:         return ja("ショートカット効率", en: "Shortcut Efficiency")
-        case .mouseDistance:              return ja("マウス移動距離", en: "Mouse Distance")
         case .slowEvents:                 return ja("低速イベント数", en: "Slow Events")
         }
     }
@@ -1561,30 +1569,24 @@ final class L10n {
 
     // MARK: - Mouse Distance
 
-    /// Mouse distance display string. Shows raw screen points and physical distance.
-    /// Physical distance uses NSScreen.main for accuracy, falling back to 96 dpi baseline.
-    func mouseDistanceDisplay(_ pts: Double) -> String {
-        // Derive mm/pt from screen DPI; fall back to 96 dpi baseline (0.264 mm/pt)
+    func mouseDistanceString(_ pts: Double) -> String {
         let mmPerPt: Double
         if let screen = NSScreen.main,
            let res = screen.deviceDescription[NSDeviceDescriptionKey("NSDeviceResolution")] as? NSSize,
            res.width > 0 {
-            mmPerPt = 25.4 / res.width  // 25.4 mm per inch / dpi
+            mmPerPt = 25.4 / res.width
         } else {
             mmPerPt = 0.264
         }
-
         let meters = pts * mmPerPt / 1000.0
+        return meters >= 1000
+            ? String(format: "%.2f km", meters / 1000)
+            : String(format: "%.0f m", meters)
+    }
 
-        let distStr: String
-        if meters >= 1000 {
-            distStr = String(format: "%.2f km", meters / 1000)
-        } else {
-            distStr = String(format: "%.0f m", meters)
-        }
-
-        return ja("🖱 本日: \(distStr)",
-                  en: "🖱 Today: \(distStr)")
+    func mouseDistanceDisplay(_ pts: Double) -> String {
+        let distStr = mouseDistanceString(pts)
+        return ja("🖱 本日: \(distStr)", en: "🖱 Today: \(distStr)")
     }
 
     var mouseDistanceNoData: String {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -60,9 +60,9 @@ final class L10n {
         let keysStr = keys.formatted()
         if let pts = mousePts {
             let dist = mouseDistanceString(pts)
-            return ja("本日: \(keysStr) keys, \(dist) move", en: "Today: \(keysStr) keys, \(dist) move")
+            return ja("本日: \(keysStr) 打鍵, \(dist) 移動", en: "Today: \(keysStr) keys, \(dist) move")
         }
-        return ja("本日: \(keysStr) keys", en: "Today: \(keysStr) keys")
+        return ja("本日: \(keysStr) 打鍵", en: "Today: \(keysStr) keys")
     }
 
     var noInput: String {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -60,7 +60,7 @@ final class L10n {
         let keysStr = keys.formatted()
         if let pts = mousePts {
             let dist = mouseDistanceString(pts)
-            return ja("本日: \(keysStr) keys, \(dist)", en: "Today: \(keysStr) keys, \(dist)")
+            return ja("本日: \(keysStr) keys, \(dist) move", en: "Today: \(keysStr) keys, \(dist) move")
         }
         return ja("本日: \(keysStr) keys", en: "Today: \(keysStr) keys")
     }

--- a/Sources/KeyLens/MenuView.swift
+++ b/Sources/KeyLens/MenuView.swift
@@ -66,8 +66,8 @@ struct MenuView: View {
                 switch widget {
                 case .recordingSince:
                     infoRow(l.recordingSince(store.startedAt), icon: "calendar")
-                case .todayTotal:
-                    menuRow(String(format: l.todayFormat, store.todayCount.formatted()), icon: "keyboard") {
+                case .todaySummary:
+                    menuRow(l.todaySummaryDisplay(keys: store.todayCount, mousePts: MouseStore.shared.distanceToday()), icon: "figure.typing") {
                         appDelegate.showChartsAtSessions()
                     }
                 case .avgInterval:
@@ -100,16 +100,6 @@ struct MenuView: View {
                         infoRow(l.shortcutEfficiencyDisplay(pct))
                     } else {
                         infoRow(l.shortcutEfficiencyNoData)
-                    }
-                case .mouseDistance:
-                    if let pts = MouseStore.shared.distanceToday() {
-                        menuRow(l.mouseDistanceDisplay(pts)) {
-                            appDelegate.showMouseDistanceChart()
-                        }
-                    } else {
-                        menuRow(l.mouseDistanceNoData) {
-                            appDelegate.showMouseDistanceChart()
-                        }
                     }
                 case .slowEvents:
                     let count = KeyCountStore.shared.slowEventCount

--- a/Sources/KeyLens/MenuView.swift
+++ b/Sources/KeyLens/MenuView.swift
@@ -67,7 +67,7 @@ struct MenuView: View {
                 case .recordingSince:
                     infoRow(l.recordingSince(store.startedAt), icon: "calendar")
                 case .todaySummary:
-                    menuRow(l.todaySummaryDisplay(keys: store.todayCount, mousePts: MouseStore.shared.distanceToday()), icon: "figure.typing") {
+                    menuRow(l.todaySummaryDisplay(keys: store.todayCount, mousePts: MouseStore.shared.distanceToday()), icon: "keyboard.fill") {
                         appDelegate.showChartsAtSessions()
                     }
                 case .avgInterval:

--- a/Sources/KeyLens/MenuWidgetStore.swift
+++ b/Sources/KeyLens/MenuWidgetStore.swift
@@ -6,14 +6,13 @@ import Combine
 /// Represents a toggleable stat widget shown in the menu bar popover.
 /// メニューバーポップオーバーに表示する統計ウィジェットを定義する列挙型。
 enum MenuWidget: String, CaseIterable, Identifiable {
-    case recordingSince = "recordingSince"
-    case todayTotal     = "todayTotal"
-    case avgInterval    = "avgInterval"
-    case estimatedWPM   = "estimatedWPM"
+    case recordingSince  = "recordingSince"
+    case todaySummary    = "todaySummary"
+    case avgInterval     = "avgInterval"
+    case estimatedWPM    = "estimatedWPM"
     case miniChart            = "miniChart"
     case streak               = "streak"
     case shortcutEfficiency   = "shortcutEfficiency"
-    case mouseDistance        = "mouseDistance"
     case slowEvents           = "slowEvents"
 
     var id: String { rawValue }
@@ -42,7 +41,7 @@ final class MenuWidgetStore: ObservableObject {
     /// Default order matching current hardcoded behaviour.
     /// 既存の表示順と一致するデフォルト順序。
     static let defaultOrder: [MenuWidget] = [
-        .todayTotal, .miniChart, .estimatedWPM, .mouseDistance,
+        .todaySummary, .miniChart, .estimatedWPM,
         .avgInterval, .shortcutEfficiency, .streak,
         .recordingSince, .slowEvents
     ]


### PR DESCRIPTION
## Summary

- Replaced `todayTotal` and `mouseDistance` widgets with a single `todaySummary` widget
- Shows `"Today: 1,234 · 52 m"` on one row with a `figure.typing` icon
- Falls back to `"Today: 1,234"` if no mouse data is available
- Extracted `mouseDistanceString()` helper to share distance formatting between the old standalone display and the new summary
- Clicking opens Charts → Typing → Activity → Volume

Closes #362

## Test plan

- [ ] Menu shows single "Today: X · Y m" row with figure.typing icon
- [ ] Clicking navigates to Typing/Activity/Volume
- [ ] When no mouse data, shows "Today: X" only
- [ ] Menu Customize panel shows "Today Summary" widget (replaces old two entries)