### PR TITLE
feat: add Effort heatmap mode (#372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ KeyLens changes that. It records which keys you press, how often, and with which
 - See which fingers are overloaded and how the load is distributed across both hands
 - Simulate how Colemak, Dvorak, or a custom layout would affect your travel distance, using your actual data
 - Track WPM, keystroke rhythm, and fatigue over days and weeks
-- Break down keystrokes by app — useful for knowing where to focus changes first
 - See which shortcuts you use most and whether your modifier placement is costing you
-- Track daily cursor distance alongside your keyboard data
-- A floating overlay shows your last few keystrokes live, useful for learning a new layout
 
 ---
 

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -869,13 +869,19 @@ struct HeatmapExportView: View {
     static let effortScores: [String: Double] = {
         var scores: [String: Double] = [:]
         for (name, pos) in ANSILayout.positionNameTable {
-            // Row 4 is the thumb row (Space, modifiers). Thumb reach is natural,
-            // so row distance is treated as 0 — only finger weakness applies.
-            let rowDiff = pos.row == 4 ? 0 : min(abs(pos.row - 2), 4)
+            let rowDiff = min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
             scores[name] = min(rowPart + fingerPenalty, 10.0)
         }
+        // Thumb cluster overrides — formula overestimates modifier difficulty
+        // because thumb reach varies per key. Tune these values as needed.
+        let thumbOverrides: [String: Double] = [
+            "Space":    1.0,  // natural thumb press, very easy
+            "⌘Cmd":     4.0,  // thumb shifts inward slightly
+            "⌥Option":  6.0,  // larger thumb shift, less natural
+        ]
+        for (name, score) in thumbOverrides { scores[name] = score }
         let shiftedToBase: [String: String] = [
             "~": "`",  "!": "1",  "@": "2",  "#": "3",  "$": "4",
             "%": "5",  "^": "6",  "&": "7",  "*": "8",  "(": "9",

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -359,8 +359,10 @@ struct KeyboardHeatmapView: View {
             let maxMs = vm.speedScores.values.max() ?? 1.0
             return (Int(ms * 100), Int(maxMs * 100))
         case .effort:
-            let score = HeatmapExportView.effortScores[keyName] ?? 0
-            return (Int(score * 10), 100)
+            if let score = HeatmapExportView.effortScores[keyName] {
+                return (Int(score * 10) + 1, 101)
+            }
+            return (0, 101)
         }
     }
 
@@ -914,8 +916,12 @@ struct HeatmapExportView: View {
             let ms = speedScores[keyName] ?? 0
             return (Int(ms * 100), Int(maxSpeedScore * 100))
         case .effort:
-            let score = Self.effortScores[keyName] ?? 0
-            return (Int(score * 10), 100)
+            // Shift by 1 so score=0 (easiest key) → count=1, not 0.
+            // count=0 is reserved for keys not in the ANSI table (→ gray).
+            if let score = Self.effortScores[keyName] {
+                return (Int(score * 10) + 1, 101)
+            }
+            return (0, 101)
         }
     }
 
@@ -927,8 +933,7 @@ struct HeatmapExportView: View {
 
     // Returns effort score tooltip text, or nil if not in effort mode.
     private func effortTooltipText(for keyName: String) -> String? {
-        guard mode == .effort else { return nil }
-        let score = Self.effortScores[keyName] ?? 0
+        guard mode == .effort, let score = Self.effortScores[keyName] else { return nil }
         return L10n.shared.heatmapEffortTooltip(score)
     }
 

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -869,7 +869,9 @@ struct HeatmapExportView: View {
     static let effortScores: [String: Double] = {
         var scores: [String: Double] = [:]
         for (name, pos) in ANSILayout.positionNameTable {
-            let rowDiff = min(abs(pos.row - 2), 4)
+            // Row 4 is the thumb row (Space, modifiers). Thumb reach is natural,
+            // so row distance is treated as 0 — only finger weakness applies.
+            let rowDiff = pos.row == 4 ? 0 : min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
             scores[name] = min(rowPart + fingerPenalty, 10.0)

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -458,7 +458,7 @@ struct KeyboardHeatmapView: View {
                             )
                             .font(.callout)
                             .padding(10)
-                            .frame(width: 280)
+                            .frame(width: mode == .effort ? 340 : 280)
                             .fixedSize(horizontal: false, vertical: true)
                         }
 

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -862,14 +862,28 @@ struct HeatmapExportView: View {
     // Static positional effort scores (0–10) keyed by key name.
     // Formula: row distance from home row (row 2) contributes up to 8 points;
     // finger weakness (1 - capability weight) contributes up to 2 points.
+    // Shifted symbols (e.g. "@" for "2") are aliased to the same score as their base key
+    // so custom KLE layouts whose primary legend is the shifted symbol still get scored.
     static let effortScores: [String: Double] = {
-        ANSILayout.positionNameTable.reduce(into: [:]) { result, pair in
-            let pos = pair.value
+        var scores: [String: Double] = [:]
+        for (name, pos) in ANSILayout.positionNameTable {
             let rowDiff = min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
-            result[pair.key] = min(rowPart + fingerPenalty, 10.0)
+            scores[name] = min(rowPart + fingerPenalty, 10.0)
         }
+        let shiftedToBase: [String: String] = [
+            "~": "`",  "!": "1",  "@": "2",  "#": "3",  "$": "4",
+            "%": "5",  "^": "6",  "&": "7",  "*": "8",  "(": "9",
+            ")": "0",  "_": "-",  "+": "=",
+            "{": "[",  "}": "]",  "|": "\\",
+            ":": ";",  "\"": "'",
+            "<": ",",  ">": ".",  "?": "/",
+        ]
+        for (shifted, base) in shiftedToBase {
+            if let s = scores[base] { scores[shifted] = s }
+        }
+        return scores
     }()
 
     // HeatmapExportView always receives an already-resolved template from the parent.

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -439,7 +439,7 @@ struct KeyboardHeatmapView: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .frame(maxWidth: 220)
+                    .frame(maxWidth: 290)
 
                     Image(systemName: "info.circle")
                         .font(.body)

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -7,6 +7,7 @@ enum HeatmapMode: String, CaseIterable {
     case frequency = "Frequency"
     case strain    = "Strain"
     case speed     = "Speed"
+    case effort    = "Effort"
 }
 
 // MARK: - HeatmapTemplate
@@ -357,6 +358,9 @@ struct KeyboardHeatmapView: View {
             let ms = vm.speedScores[keyName] ?? 0
             let maxMs = vm.speedScores.values.max() ?? 1.0
             return (Int(ms * 100), Int(maxMs * 100))
+        case .effort:
+            let score = HeatmapExportView.effortScores[keyName] ?? 0
+            return (Int(score * 10), 100)
         }
     }
 
@@ -446,7 +450,9 @@ struct KeyboardHeatmapView: View {
                                 ? L10n.shared.helpHeatmapStrain
                                 : mode == .speed
                                     ? L10n.shared.helpHeatmapSpeed
-                                    : L10n.shared.helpHeatmapFrequency
+                                    : mode == .effort
+                                        ? L10n.shared.helpHeatmapEffort
+                                        : L10n.shared.helpHeatmapFrequency
                             )
                             .font(.callout)
                             .padding(10)
@@ -853,6 +859,19 @@ struct HeatmapExportView: View {
     private var maxStrainScore: Int { strainScores.values.max() ?? 1 }
     private var maxSpeedScore: Double { speedScores.values.max() ?? 1.0 }
 
+    // Static positional effort scores (0–10) keyed by key name.
+    // Formula: row distance from home row (row 2) contributes up to 8 points;
+    // finger weakness (1 - capability weight) contributes up to 2 points.
+    static let effortScores: [String: Double] = {
+        ANSILayout.positionNameTable.reduce(into: [:]) { result, pair in
+            let pos = pair.value
+            let rowDiff = min(abs(pos.row - 2), 4)
+            let rowPart = Double(rowDiff) / 2.0 * 8.0
+            let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
+            result[pair.key] = min(rowPart + fingerPenalty, 10.0)
+        }
+    }()
+
     // HeatmapExportView always receives an already-resolved template from the parent.
     // This alias exists so the internal switches read identically to KeyboardHeatmapView.
     private var effectiveTemplate: HeatmapTemplate { template }
@@ -880,6 +899,9 @@ struct HeatmapExportView: View {
         case .speed:
             let ms = speedScores[keyName] ?? 0
             return (Int(ms * 100), Int(maxSpeedScore * 100))
+        case .effort:
+            let score = Self.effortScores[keyName] ?? 0
+            return (Int(score * 10), 100)
         }
     }
 
@@ -887,6 +909,13 @@ struct HeatmapExportView: View {
     private func speedTooltipText(for keyName: String) -> String? {
         guard mode == .speed, let ms = speedScores[keyName] else { return nil }
         return L10n.shared.heatmapSpeedTooltip(ms)
+    }
+
+    // Returns effort score tooltip text, or nil if not in effort mode.
+    private func effortTooltipText(for keyName: String) -> String? {
+        guard mode == .effort else { return nil }
+        let score = Self.effortScores[keyName] ?? 0
+        return L10n.shared.heatmapEffortTooltip(score)
     }
 
     // Returns the row definitions for the current template.
@@ -962,7 +991,7 @@ struct HeatmapExportView: View {
                                         width: cellW,
                                         height: cellH,
                                         tooltipStyle: mode == .strain ? .strain : .count,
-                                        tooltipOverride: speedTooltipText(for: key.keyName)
+                                        tooltipOverride: speedTooltipText(for: key.keyName) ?? effortTooltipText(for: key.keyName)
                                     )
                                     .rotationEffect(.degrees(key.r))
                                     .offset(x: CGFloat(key.cx) * unitW - cellW / 2,
@@ -1000,7 +1029,7 @@ struct HeatmapExportView: View {
                         max: displayMax,
                         width: unitWidth * CGFloat(key.widthRatio),
                         tooltipStyle: mode == .strain ? .strain : .count,
-                        tooltipOverride: speedTooltipText(for: key.keyName)
+                        tooltipOverride: speedTooltipText(for: key.keyName) ?? effortTooltipText(for: key.keyName)
                     )
                 }
             }
@@ -1171,8 +1200,8 @@ struct HeatmapExportView: View {
 
     private var legend: some View {
         let l = L10n.shared
-        let lowLabel  = mode == .strain ? "Low strain"  : mode == .speed ? l.heatmapSpeedLow  : l.heatmapLow
-        let highLabel = mode == .strain ? "High strain" : mode == .speed ? l.heatmapSpeedHigh : l.heatmapHigh
+        let lowLabel  = mode == .strain ? "Low strain"  : mode == .speed ? l.heatmapSpeedLow  : mode == .effort ? l.heatmapEffortLow  : l.heatmapLow
+        let highLabel = mode == .strain ? "High strain" : mode == .speed ? l.heatmapSpeedHigh : mode == .effort ? l.heatmapEffortHigh : l.heatmapHigh
         return HStack(spacing: 6) {
             Text(lowLabel).font(.caption2).foregroundStyle(.secondary)
             LinearGradient(

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -919,7 +919,7 @@ final class L10n {
 
            スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
 
-           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt) · 親指段(0pt)
            指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
 
            例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
@@ -929,7 +929,7 @@ final class L10n {
 
            Score = row distance (0–8) + finger weakness (0–2)
 
-           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt) · thumb row (0pt)
            Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
 
            e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -919,7 +919,7 @@ final class L10n {
 
            スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
 
-           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt) · 親指段(0pt)
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
            指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
 
            例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
@@ -929,7 +929,7 @@ final class L10n {
 
            Score = row distance (0–8) + finger weakness (0–2)
 
-           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt) · thumb row (0pt)
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
            Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
 
            e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -905,6 +905,23 @@ final class L10n {
            en: "Speed mode: each key is colored by its average inter-keystroke interval (IKI) across related bigrams. Red = slowest key. Requires at least 3 bigrams of data per key.")
     }
 
+    var heatmapEffortLow: String {
+        ja("楽", en: "Easy")
+    }
+
+    var heatmapEffortHigh: String {
+        ja("きつい", en: "Hard")
+    }
+
+    var helpHeatmapEffort: String {
+        ja("負担モード：各キーの位置的な押しにくさを0〜10で表示します。ホームロウからの行距離と指の強さから算出されます。緑がやさしいキー、赤がきついキーです。",
+           en: "Effort mode: each key is colored by its positional effort score (0–10), computed from home-row distance and finger capability. Green = easy (home row, strong finger); red = hard (top row, weak finger).")
+    }
+
+    func heatmapEffortTooltip(_ score: Double) -> String {
+        ja(String(format: "負担スコア: %.1f / 10", score), en: String(format: "Effort: %.1f / 10", score))
+    }
+
     func heatmapSpeedTooltip(_ ms: Double) -> String {
         ja(String(format: "平均IKI: %.0f ms", ms), en: String(format: "Avg IKI: %.0f ms", ms))
     }

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -914,8 +914,26 @@ final class L10n {
     }
 
     var helpHeatmapEffort: String {
-        ja("負担モード：各キーの位置的な押しにくさを0〜10で表示します。ホームロウからの行距離と指の強さから算出されます。緑がやさしいキー、赤がきついキーです。",
-           en: "Effort mode: each key is colored by its positional effort score (0–10), computed from home-row distance and finger capability. Green = easy (home row, strong finger); red = hard (top row, weak finger).")
+        ja("""
+           負担モード：各キーの位置的な押しにくさを0〜10のスコアで色付けします。
+
+           スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
+
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
+           指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
+
+           例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
+           """,
+           en: """
+           Effort mode: each key is colored by its positional effort score (0–10).
+
+           Score = row distance (0–8) + finger weakness (0–2)
+
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
+           Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
+
+           e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0
+           """)
     }
 
     func heatmapEffortTooltip(_ score: Double) -> String {


### PR DESCRIPTION
## Summary

- Adds `.effort` to `HeatmapMode` enum alongside Frequency / Strain / Speed
- Computes static per-key effort scores (0–10) from home-row distance and finger capability using `ANSILayout.positionNameTable` + `FingerLoadWeight.default`
- Home row + strong finger → near 0; number row + pinky → up to 10
- Color gradient: green (easy) → red (hard)
- Adds EN/JA L10n keys: mode label, help popover text, legend labels, tooltip

## Formula

```swift
rowPart = Double(min(abs(pos.row - 2), 4)) / 2.0 * 8.0   // 0..8
fingerPenalty = (1.0 - fingerWeight) / 0.5 * 2.0          // 0..2
score = min(rowPart + fingerPenalty, 10.0)
```

Scores are static (not frequency-weighted), so no async computation needed.

## Test plan

- [ ] Keyboard tab shows "Effort" segment in the mode picker
- [ ] Home row keys (a s d f j k l ;) colored green, score ≤ 2
- [ ] Number row keys colored red, score ≥ 7 for pinky keys
- [ ] Tapping a key shows tooltip "Effort: X.X / 10"
- [ ] Info popover explains the scoring formula (EN + JA)
- [ ] Switching back to Frequency / Strain / Speed works correctly
- [ ] Zero build warnings