### PR TITLE
fix: move CGEventTap to dedicated background thread (#376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,7 @@ KeyLens changes that. It records which keys you press, how often, and with which
 - See which fingers are overloaded and how the load is distributed across both hands
 - Simulate how Colemak, Dvorak, or a custom layout would affect your travel distance, using your actual data
 - Track WPM, keystroke rhythm, and fatigue over days and weeks
-- Break down keystrokes by app — useful for knowing where to focus changes first
 - See which shortcuts you use most and whether your modifier placement is costing you
-- Track daily cursor distance alongside your keyboard data
-- A floating overlay shows your last few keystrokes live, useful for learning a new layout
 
 ---
 

--- a/Sources/KeyLens/AppDelegate.swift
+++ b/Sources/KeyLens/AppDelegate.swift
@@ -12,6 +12,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private var hidManager: IOHIDManager?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "?"
+        KeyLens.log("=== KeyLens \(version) (build \(build)) started ===")
         _ = NotificationManager.shared
         _ = KeystrokeOverlayController.shared
         ThemeStore.shared.appearance.apply()

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -869,13 +869,19 @@ struct HeatmapExportView: View {
     static let effortScores: [String: Double] = {
         var scores: [String: Double] = [:]
         for (name, pos) in ANSILayout.positionNameTable {
-            // Row 4 is the thumb row (Space, modifiers). Thumb reach is natural,
-            // so row distance is treated as 0 — only finger weakness applies.
-            let rowDiff = pos.row == 4 ? 0 : min(abs(pos.row - 2), 4)
+            let rowDiff = min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
             scores[name] = min(rowPart + fingerPenalty, 10.0)
         }
+        // Thumb cluster overrides — formula overestimates modifier difficulty
+        // because thumb reach varies per key. Tune these values as needed.
+        let thumbOverrides: [String: Double] = [
+            "Space":    1.0,  // natural thumb press, very easy
+            "⌘Cmd":     4.0,  // thumb shifts inward slightly
+            "⌥Option":  6.0,  // larger thumb shift, less natural
+        ]
+        for (name, score) in thumbOverrides { scores[name] = score }
         let shiftedToBase: [String: String] = [
             "~": "`",  "!": "1",  "@": "2",  "#": "3",  "$": "4",
             "%": "5",  "^": "6",  "&": "7",  "*": "8",  "(": "9",

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -359,8 +359,10 @@ struct KeyboardHeatmapView: View {
             let maxMs = vm.speedScores.values.max() ?? 1.0
             return (Int(ms * 100), Int(maxMs * 100))
         case .effort:
-            let score = HeatmapExportView.effortScores[keyName] ?? 0
-            return (Int(score * 10), 100)
+            if let score = HeatmapExportView.effortScores[keyName] {
+                return (Int(score * 10) + 1, 101)
+            }
+            return (0, 101)
         }
     }
 
@@ -914,8 +916,12 @@ struct HeatmapExportView: View {
             let ms = speedScores[keyName] ?? 0
             return (Int(ms * 100), Int(maxSpeedScore * 100))
         case .effort:
-            let score = Self.effortScores[keyName] ?? 0
-            return (Int(score * 10), 100)
+            // Shift by 1 so score=0 (easiest key) → count=1, not 0.
+            // count=0 is reserved for keys not in the ANSI table (→ gray).
+            if let score = Self.effortScores[keyName] {
+                return (Int(score * 10) + 1, 101)
+            }
+            return (0, 101)
         }
     }
 
@@ -927,8 +933,7 @@ struct HeatmapExportView: View {
 
     // Returns effort score tooltip text, or nil if not in effort mode.
     private func effortTooltipText(for keyName: String) -> String? {
-        guard mode == .effort else { return nil }
-        let score = Self.effortScores[keyName] ?? 0
+        guard mode == .effort, let score = Self.effortScores[keyName] else { return nil }
         return L10n.shared.heatmapEffortTooltip(score)
     }
 

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -869,7 +869,9 @@ struct HeatmapExportView: View {
     static let effortScores: [String: Double] = {
         var scores: [String: Double] = [:]
         for (name, pos) in ANSILayout.positionNameTable {
-            let rowDiff = min(abs(pos.row - 2), 4)
+            // Row 4 is the thumb row (Space, modifiers). Thumb reach is natural,
+            // so row distance is treated as 0 — only finger weakness applies.
+            let rowDiff = pos.row == 4 ? 0 : min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
             scores[name] = min(rowPart + fingerPenalty, 10.0)

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -458,7 +458,7 @@ struct KeyboardHeatmapView: View {
                             )
                             .font(.callout)
                             .padding(10)
-                            .frame(width: 280)
+                            .frame(width: mode == .effort ? 340 : 280)
                             .fixedSize(horizontal: false, vertical: true)
                         }
 

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -862,14 +862,28 @@ struct HeatmapExportView: View {
     // Static positional effort scores (0–10) keyed by key name.
     // Formula: row distance from home row (row 2) contributes up to 8 points;
     // finger weakness (1 - capability weight) contributes up to 2 points.
+    // Shifted symbols (e.g. "@" for "2") are aliased to the same score as their base key
+    // so custom KLE layouts whose primary legend is the shifted symbol still get scored.
     static let effortScores: [String: Double] = {
-        ANSILayout.positionNameTable.reduce(into: [:]) { result, pair in
-            let pos = pair.value
+        var scores: [String: Double] = [:]
+        for (name, pos) in ANSILayout.positionNameTable {
             let rowDiff = min(abs(pos.row - 2), 4)
             let rowPart = Double(rowDiff) / 2.0 * 8.0
             let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
-            result[pair.key] = min(rowPart + fingerPenalty, 10.0)
+            scores[name] = min(rowPart + fingerPenalty, 10.0)
         }
+        let shiftedToBase: [String: String] = [
+            "~": "`",  "!": "1",  "@": "2",  "#": "3",  "$": "4",
+            "%": "5",  "^": "6",  "&": "7",  "*": "8",  "(": "9",
+            ")": "0",  "_": "-",  "+": "=",
+            "{": "[",  "}": "]",  "|": "\\",
+            ":": ";",  "\"": "'",
+            "<": ",",  ">": ".",  "?": "/",
+        ]
+        for (shifted, base) in shiftedToBase {
+            if let s = scores[base] { scores[shifted] = s }
+        }
+        return scores
     }()
 
     // HeatmapExportView always receives an already-resolved template from the parent.

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -439,7 +439,7 @@ struct KeyboardHeatmapView: View {
                         }
                     }
                     .pickerStyle(.segmented)
-                    .frame(maxWidth: 220)
+                    .frame(maxWidth: 290)
 
                     Image(systemName: "info.circle")
                         .font(.body)

--- a/Sources/KeyLens/KeyboardHeatmapView.swift
+++ b/Sources/KeyLens/KeyboardHeatmapView.swift
@@ -7,6 +7,7 @@ enum HeatmapMode: String, CaseIterable {
     case frequency = "Frequency"
     case strain    = "Strain"
     case speed     = "Speed"
+    case effort    = "Effort"
 }
 
 // MARK: - HeatmapTemplate
@@ -357,6 +358,9 @@ struct KeyboardHeatmapView: View {
             let ms = vm.speedScores[keyName] ?? 0
             let maxMs = vm.speedScores.values.max() ?? 1.0
             return (Int(ms * 100), Int(maxMs * 100))
+        case .effort:
+            let score = HeatmapExportView.effortScores[keyName] ?? 0
+            return (Int(score * 10), 100)
         }
     }
 
@@ -446,7 +450,9 @@ struct KeyboardHeatmapView: View {
                                 ? L10n.shared.helpHeatmapStrain
                                 : mode == .speed
                                     ? L10n.shared.helpHeatmapSpeed
-                                    : L10n.shared.helpHeatmapFrequency
+                                    : mode == .effort
+                                        ? L10n.shared.helpHeatmapEffort
+                                        : L10n.shared.helpHeatmapFrequency
                             )
                             .font(.callout)
                             .padding(10)
@@ -853,6 +859,19 @@ struct HeatmapExportView: View {
     private var maxStrainScore: Int { strainScores.values.max() ?? 1 }
     private var maxSpeedScore: Double { speedScores.values.max() ?? 1.0 }
 
+    // Static positional effort scores (0–10) keyed by key name.
+    // Formula: row distance from home row (row 2) contributes up to 8 points;
+    // finger weakness (1 - capability weight) contributes up to 2 points.
+    static let effortScores: [String: Double] = {
+        ANSILayout.positionNameTable.reduce(into: [:]) { result, pair in
+            let pos = pair.value
+            let rowDiff = min(abs(pos.row - 2), 4)
+            let rowPart = Double(rowDiff) / 2.0 * 8.0
+            let fingerPenalty = (1.0 - FingerLoadWeight.default.weight(for: pos.finger)) / 0.5 * 2.0
+            result[pair.key] = min(rowPart + fingerPenalty, 10.0)
+        }
+    }()
+
     // HeatmapExportView always receives an already-resolved template from the parent.
     // This alias exists so the internal switches read identically to KeyboardHeatmapView.
     private var effectiveTemplate: HeatmapTemplate { template }
@@ -880,6 +899,9 @@ struct HeatmapExportView: View {
         case .speed:
             let ms = speedScores[keyName] ?? 0
             return (Int(ms * 100), Int(maxSpeedScore * 100))
+        case .effort:
+            let score = Self.effortScores[keyName] ?? 0
+            return (Int(score * 10), 100)
         }
     }
 
@@ -887,6 +909,13 @@ struct HeatmapExportView: View {
     private func speedTooltipText(for keyName: String) -> String? {
         guard mode == .speed, let ms = speedScores[keyName] else { return nil }
         return L10n.shared.heatmapSpeedTooltip(ms)
+    }
+
+    // Returns effort score tooltip text, or nil if not in effort mode.
+    private func effortTooltipText(for keyName: String) -> String? {
+        guard mode == .effort else { return nil }
+        let score = Self.effortScores[keyName] ?? 0
+        return L10n.shared.heatmapEffortTooltip(score)
     }
 
     // Returns the row definitions for the current template.
@@ -962,7 +991,7 @@ struct HeatmapExportView: View {
                                         width: cellW,
                                         height: cellH,
                                         tooltipStyle: mode == .strain ? .strain : .count,
-                                        tooltipOverride: speedTooltipText(for: key.keyName)
+                                        tooltipOverride: speedTooltipText(for: key.keyName) ?? effortTooltipText(for: key.keyName)
                                     )
                                     .rotationEffect(.degrees(key.r))
                                     .offset(x: CGFloat(key.cx) * unitW - cellW / 2,
@@ -1000,7 +1029,7 @@ struct HeatmapExportView: View {
                         max: displayMax,
                         width: unitWidth * CGFloat(key.widthRatio),
                         tooltipStyle: mode == .strain ? .strain : .count,
-                        tooltipOverride: speedTooltipText(for: key.keyName)
+                        tooltipOverride: speedTooltipText(for: key.keyName) ?? effortTooltipText(for: key.keyName)
                     )
                 }
             }
@@ -1171,8 +1200,8 @@ struct HeatmapExportView: View {
 
     private var legend: some View {
         let l = L10n.shared
-        let lowLabel  = mode == .strain ? "Low strain"  : mode == .speed ? l.heatmapSpeedLow  : l.heatmapLow
-        let highLabel = mode == .strain ? "High strain" : mode == .speed ? l.heatmapSpeedHigh : l.heatmapHigh
+        let lowLabel  = mode == .strain ? "Low strain"  : mode == .speed ? l.heatmapSpeedLow  : mode == .effort ? l.heatmapEffortLow  : l.heatmapLow
+        let highLabel = mode == .strain ? "High strain" : mode == .speed ? l.heatmapSpeedHigh : mode == .effort ? l.heatmapEffortHigh : l.heatmapHigh
         return HStack(spacing: 6) {
             Text(lowLabel).font(.caption2).foregroundStyle(.secondary)
             LinearGradient(

--- a/Sources/KeyLens/KeyboardMonitor.swift
+++ b/Sources/KeyLens/KeyboardMonitor.swift
@@ -64,8 +64,25 @@ private let kHandleEventSlowThresholdMs: Double = 5.0
 final class KeyboardMonitor {
     private(set) var eventTap: CFMachPort?
     private var runLoopSource: CFRunLoopSource?
-    /// Cached frontmost app name, updated via NSWorkspace notification instead of per-keystroke IPC.
-    private var cachedAppName: String?
+
+    // Dedicated background thread and its run loop for the CGEventTap.
+    // Isolates the tap from all main-thread work (SwiftUI renders, timers) so
+    // macOS never disables it due to the ~1 s tapDisabledByTimeout threshold.
+    private var tapThread: Thread?
+    private var tapRunLoop: CFRunLoop?
+
+    // Thread-safe cached app name: written on main (workspace notification),
+    // read on the tap background thread.
+    private let appNameLock = NSLock()
+    private var _cachedAppName: String?
+    private var cachedAppName: String? {
+        get { appNameLock.withLock { _cachedAppName } }
+        set { appNameLock.withLock { _cachedAppName = newValue } }
+    }
+
+    // Observer token to avoid duplicate workspace registrations across start() calls.
+    private var appNameObserver: Any?
+
     /// Counter for throttling heatmap position sampling (sample every 5th mouseMoved event).
     private var mouseSampleCounter: Int = 0
 
@@ -99,18 +116,33 @@ final class KeyboardMonitor {
         KeyLens.log("start() called — AXIsProcessTrusted: \(trusted)")
         guard trusted else { return false }
 
-        // 既存タップの再有効化を先に試みる（権限再付与後の高速復帰）
+        // Fast path: re-enable an existing tap without recreating the thread.
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: true)
             if CGEvent.tapIsEnabled(tap: tap) {
                 KeyLens.log("Existing tap re-enabled successfully")
                 return true
             }
-            // 再有効化できなかった場合は破棄して新規作成
             KeyLens.log("Existing tap could not be re-enabled — recreating")
             stop()
         }
 
+        // Seed app name cache (main thread; safe here since tap thread not yet running).
+        _cachedAppName = NSWorkspace.shared.frontmostApplication?.localizedName
+
+        // Register workspace observer once; keep token to avoid duplicates.
+        if appNameObserver == nil {
+            appNameObserver = NotificationCenter.default.addObserver(
+                forName: NSWorkspace.didActivateApplicationNotification,
+                object: NSWorkspace.shared,
+                queue: .main
+            ) { [weak self] note in
+                let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
+                self?.cachedAppName = app?.localizedName
+            }
+        }
+
+        // Build event mask once so the closure captures only a value type.
         var mask = CGEventMask(1 << CGEventType.keyDown.rawValue)
         mask |= CGEventMask(1 << CGEventType.keyUp.rawValue)
         mask |= CGEventMask(1 << CGEventType.leftMouseDown.rawValue)
@@ -118,49 +150,75 @@ final class KeyboardMonitor {
         mask |= CGEventMask(1 << CGEventType.otherMouseDown.rawValue)
         mask |= CGEventMask(1 << CGEventType.mouseMoved.rawValue)
 
-        // .listenOnly + .tailAppendEventTap = 最小権限での監視
-        // userInfo に self を渡すことで、コールバックが AppDelegate に依存せず tap を再有効化できる
-        let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .tailAppendEventTap,
-            options: .listenOnly,
-            eventsOfInterest: mask,
-            callback: inputTapCallback,
-            userInfo: Unmanaged.passUnretained(self).toOpaque()
-        )
-        KeyLens.log("CGEvent.tapCreate result: \(tap != nil ? "success" : "nil (FAILED)")")
-        guard let tap else { return false }
+        // Semaphore to wait for the background thread to finish tap setup.
+        let setupDone = DispatchSemaphore(value: 0)
+        var tapCreated = false
 
-        eventTap = tap
-        let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
-        runLoopSource = source
-        CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
-        CGEvent.tapEnable(tap: tap, enable: true)
+        let thread = Thread { [weak self] in
+            guard let self else { setupDone.signal(); return }
 
-        // Seed the cache immediately, then keep it fresh via notification.
-        cachedAppName = NSWorkspace.shared.frontmostApplication?.localizedName
-        NotificationCenter.default.addObserver(
-            forName: NSWorkspace.didActivateApplicationNotification,
-            object: NSWorkspace.shared,
-            queue: .main
-        ) { [weak self] note in
-            let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication
-            self?.cachedAppName = app?.localizedName
+            // Capture this thread's run loop before signalling.
+            let rl = CFRunLoopGetCurrent()!
+            self.tapRunLoop = rl
+
+            // Create and attach the tap here so its run loop source lives on this thread.
+            let tap = CGEvent.tapCreate(
+                tap: .cgSessionEventTap,
+                place: .tailAppendEventTap,
+                options: .listenOnly,
+                eventsOfInterest: mask,
+                callback: inputTapCallback,
+                userInfo: Unmanaged.passUnretained(self).toOpaque()
+            )
+            KeyLens.log("CGEvent.tapCreate result: \(tap != nil ? "success" : "nil (FAILED)")")
+
+            if let tap {
+                self.eventTap = tap
+                let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+                self.runLoopSource = source
+                CFRunLoopAddSource(rl, source, .commonModes)
+                CGEvent.tapEnable(tap: tap, enable: true)
+                tapCreated = true
+            }
+            setupDone.signal()
+
+            // Run the run loop until stop() calls CFRunLoopStop.
+            if tapCreated { CFRunLoopRun() }
+
+            self.tapRunLoop = nil
+        }
+        thread.name = "com.keylens.eventtap"
+        thread.qualityOfService = .userInteractive
+        tapThread = thread
+        thread.start()
+
+        // Block until tap is set up (or fails). 2 s timeout is generous for system calls.
+        let waitResult = setupDone.wait(timeout: .now() + 2.0)
+        if waitResult == .timedOut {
+            KeyLens.log("⚠️ Tap thread setup timed out")
+            return false
         }
 
-        KeyLens.log("Monitoring started successfully")
-        return true
+        if tapCreated {
+            KeyLens.log("Monitoring started successfully")
+        }
+        return tapCreated
     }
 
     func stop() {
         if let tap = eventTap {
             CGEvent.tapEnable(tap: tap, enable: false)
         }
-        if let src = runLoopSource {
-            CFRunLoopRemoveSource(CFRunLoopGetMain(), src, .commonModes)
+        if let src = runLoopSource, let rl = tapRunLoop {
+            CFRunLoopRemoveSource(rl, src, .commonModes)
+        }
+        if let rl = tapRunLoop {
+            CFRunLoopStop(rl)
         }
         eventTap = nil
         runLoopSource = nil
+        // tapRunLoop is cleared by the background thread after CFRunLoopRun() returns.
+        tapThread = nil
     }
 
     /// CGKeyCode → 表示用キー名
@@ -260,7 +318,7 @@ private func inputTapCallback(
 
 extension KeyboardMonitor {
     /// Handles a single CGEventTap event. Called from the global trampoline via refcon.
-    /// グローバルトランポリンから refcon 経由で呼ばれるイベントハンドラ。
+    /// Runs on the dedicated tap background thread — never on the main thread.
     func handleEvent(
         proxy: CGEventTapProxy,
         type: CGEventType,
@@ -277,7 +335,8 @@ extension KeyboardMonitor {
                 if delayMs <= 100 {
                     CGEvent.tapEnable(tap: tap, enable: true)
                 } else {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(delayMs)) { [weak self] in
+                    // Use a global queue — no longer safe to dispatch to main for tap re-enable.
+                    DispatchQueue.global(qos: .userInteractive).asyncAfter(deadline: .now() + .milliseconds(delayMs)) { [weak self] in
                         guard let tap = self?.eventTap else { return }
                         CGEvent.tapEnable(tap: tap, enable: true)
                     }
@@ -298,6 +357,7 @@ extension KeyboardMonitor {
 
         // Mouse movement: accumulate distance and sample position for heatmap.
         // Position is sampled every 5th event to keep overhead minimal.
+        // NSScreen.screens must be called on the main thread — dispatch the lookup async.
         if type == .mouseMoved {
             let dx = event.getDoubleValueField(.mouseEventDeltaX)
             let dy = event.getDoubleValueField(.mouseEventDeltaY)
@@ -307,14 +367,13 @@ extension KeyboardMonitor {
             if mouseSampleCounter >= 5 {
                 mouseSampleCounter = 0
                 let loc = event.location
-                // Find the screen that contains the cursor and normalize within its bounds.
-                // This handles multi-display setups correctly — each screen gets its own 0–99 grid.
-                if let screen = NSScreen.screens.first(where: { $0.frame.contains(loc) }) {
-                    let frame = screen.frame
-                    let relX = loc.x - frame.minX
-                    // NSScreen uses bottom-left origin; invert Y so top=0, bottom=99
-                    let relY = frame.maxY - loc.y
-                    MouseStore.shared.addPosition(x: relX, y: relY, screenSize: frame.size)
+                DispatchQueue.main.async {
+                    if let screen = NSScreen.screens.first(where: { $0.frame.contains(loc) }) {
+                        let frame = screen.frame
+                        let relX = loc.x - frame.minX
+                        let relY = frame.maxY - loc.y
+                        MouseStore.shared.addPosition(x: relX, y: relY, screenSize: frame.size)
+                    }
                 }
             }
             return Unmanaged.passRetained(event)
@@ -342,7 +401,7 @@ extension KeyboardMonitor {
             DispatchQueue.main.async { WPMHotkeyManager.shared.toggle() }
         }
 
-        // Check Overlay hotkey (Issue #179)
+        // Check Overlay hotkey (Issue #179); toggle() already dispatches to main internally.
         if type == .keyDown, OverlayHotkeyManager.shared.matches(event: event) {
             OverlayHotkeyManager.shared.toggle()
         }
@@ -354,7 +413,10 @@ extension KeyboardMonitor {
             guard let self, milestone else { return }
             self.notificationManager.notify(key: captureName, count: count)
         }
-        breakManager.didType()
+
+        // BreakReminderManager accesses its own internal state; dispatch to main for safety.
+        let bm = breakManager
+        DispatchQueue.main.async { bm.didType() }
 
         if type == .keyDown {
             let modifierKeyCodes: Set<CGKeyCode> = [54, 55, 56, 57, 58, 59, 60, 61, 62, 63]

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -919,7 +919,7 @@ final class L10n {
 
            スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
 
-           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt) · 親指段(0pt)
            指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
 
            例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
@@ -929,7 +929,7 @@ final class L10n {
 
            Score = row distance (0–8) + finger weakness (0–2)
 
-           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt) · thumb row (0pt)
            Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
 
            e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -919,7 +919,7 @@ final class L10n {
 
            スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
 
-           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt) · 親指段(0pt)
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
            指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
 
            例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
@@ -929,7 +929,7 @@ final class L10n {
 
            Score = row distance (0–8) + finger weakness (0–2)
 
-           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt) · thumb row (0pt)
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
            Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
 
            e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -905,6 +905,23 @@ final class L10n {
            en: "Speed mode: each key is colored by its average inter-keystroke interval (IKI) across related bigrams. Red = slowest key. Requires at least 3 bigrams of data per key.")
     }
 
+    var heatmapEffortLow: String {
+        ja("楽", en: "Easy")
+    }
+
+    var heatmapEffortHigh: String {
+        ja("きつい", en: "Hard")
+    }
+
+    var helpHeatmapEffort: String {
+        ja("負担モード：各キーの位置的な押しにくさを0〜10で表示します。ホームロウからの行距離と指の強さから算出されます。緑がやさしいキー、赤がきついキーです。",
+           en: "Effort mode: each key is colored by its positional effort score (0–10), computed from home-row distance and finger capability. Green = easy (home row, strong finger); red = hard (top row, weak finger).")
+    }
+
+    func heatmapEffortTooltip(_ score: Double) -> String {
+        ja(String(format: "負担スコア: %.1f / 10", score), en: String(format: "Effort: %.1f / 10", score))
+    }
+
     func heatmapSpeedTooltip(_ ms: Double) -> String {
         ja(String(format: "平均IKI: %.0f ms", ms), en: String(format: "Avg IKI: %.0f ms", ms))
     }

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -914,8 +914,26 @@ final class L10n {
     }
 
     var helpHeatmapEffort: String {
-        ja("負担モード：各キーの位置的な押しにくさを0〜10で表示します。ホームロウからの行距離と指の強さから算出されます。緑がやさしいキー、赤がきついキーです。",
-           en: "Effort mode: each key is colored by its positional effort score (0–10), computed from home-row distance and finger capability. Green = easy (home row, strong finger); red = hard (top row, weak finger).")
+        ja("""
+           負担モード：各キーの位置的な押しにくさを0〜10のスコアで色付けします。
+
+           スコア = 行距離 (0〜8) + 指の弱さ (0〜2)
+
+           行距離：ホームロウ(0pt) → 上/下段(4pt) → 数字段(8pt)
+           指の弱さ：人差し指(0pt)・中指(0.4pt)・薬指(1.6pt)・小指(2pt)
+
+           例：A = ホームロウ+小指 → 2.0 / F = ホームロウ+人差し指 → 0.0
+           """,
+           en: """
+           Effort mode: each key is colored by its positional effort score (0–10).
+
+           Score = row distance (0–8) + finger weakness (0–2)
+
+           Row distance: home row (0pt) → top/bottom row (4pt) → number row (8pt)
+           Finger weakness: index (0pt) · middle (0.4pt) · ring (1.6pt) · pinky (2pt)
+
+           e.g. A = home row + pinky → 2.0 / F = home row + index → 0.0
+           """)
     }
 
     func heatmapEffortTooltip(_ score: Double) -> String {


### PR DESCRIPTION
## Summary

- CGEventTap was added to `CFRunLoopGetMain()`, making it vulnerable to any main-thread delay (SwiftUI renders, timers). macOS disables the tap after ~1 s, causing the recurring keystroke latency.
- Moved the tap to a dedicated `Thread` (`com.keylens.eventtap`, `.userInteractive` QoS) whose own `CFRunLoop` owns the source. The main thread is now completely decoupled from keystroke capture.
- Fixed all cross-thread accesses that became unsafe once the tap left the main thread.

## Changes

**`KeyboardMonitor.start()`**
- Spawns a `Thread`; inside it, captures `CFRunLoopGetCurrent()`, creates the `CGEventTap`, adds the source to the background run loop, then calls `CFRunLoopRun()`
- Uses a `DispatchSemaphore` so `start()` blocks until tap setup succeeds (or times out after 2 s)

**`KeyboardMonitor.stop()`**
- Calls `CFRunLoopStop(tapRunLoop)` to end the background thread instead of removing from `CFRunLoopGetMain()`

**Thread-safety fixes in `handleEvent()`**
- `NSScreen.screens` (main-thread-only API) dispatched via `DispatchQueue.main.async`
- `breakManager.didType()` dispatched via `DispatchQueue.main.async`
- Delayed tap re-enable uses `DispatchQueue.global(qos: .userInteractive)` instead of main
- `cachedAppName` protected by `NSLock` (written on main, read on tap thread)
- `appNameObserver` token stored to prevent duplicate registration on repeated `start()` calls

## Test plan

- [ ] Build succeeds with zero warnings (`./build.sh --install`)
- [ ] Launch app — verify `app.log` shows "Monitoring started successfully" with no subsequent timeout messages during normal typing
- [ ] Open Charts window (keyboard heatmap) and type continuously — confirm no `CGEventTap disabled by timeout` entries appear
- [ ] Quit and relaunch — tap thread restarts cleanly