### PR TITLE
feat: support custom KLE profile in Key Swap Simulator (#373)

### DIFF
--- a/Sources/KeyLens/Charts+OptimizerTab.swift
+++ b/Sources/KeyLens/Charts+OptimizerTab.swift
@@ -69,6 +69,17 @@ final class OptimizerSimulatorState: ObservableObject {
 
     // MARK: Published state
 
+    /// Active key list used for rendering. Defaults to ANSI; updated by applyLayout().
+    @Published var activeKeys: [KLEAbsoluteKey] = OptimizerSimulatorState.ansiKeys
+
+    /// Aspect ratio of the active layout grid.
+    @Published var activeAspectRatio: CGFloat = OptimizerSimulatorState.ansiAspectRatio
+
+    /// ID of the selected KLE profile, persisted across restarts. Empty = Built-in ANSI.
+    @Published var optimizerLayoutID: String = UserDefaults.standard.string(forKey: UDKeys.optimizerLayoutID) ?? "" {
+        didSet { UserDefaults.standard.set(optimizerLayoutID, forKey: UDKeys.optimizerLayoutID) }
+    }
+
     /// Accumulated key relocation map (label → physical slot).
     /// 蓄積されたリロケーションマップ (ラベル → 物理スロット)。
     @Published var relocationMap: [String: String] = [:]
@@ -114,7 +125,7 @@ final class OptimizerSimulatorState: ObservableObject {
         }
         // Slots not targeted by any relocation show their original key.
         // どのリロケーションにも対応していないスロットは元のキーを表示。
-        for key in Self.ansiKeys where d[key.keyName] == nil && !key.keyName.isEmpty {
+        for key in activeKeys where d[key.keyName] == nil && !key.keyName.isEmpty {
             d[key.keyName] = key.keyName
         }
         return d
@@ -204,6 +215,26 @@ final class OptimizerSimulatorState: ObservableObject {
         lockedSlots      = []
         currentSnapshot  = baseSnapshot
         exportedFileName = nil
+    }
+
+    /// Switches the visual layout to a KLE profile (or back to built-in ANSI if nil).
+    /// Resets swap history since slot identities change with a new layout.
+    func applyLayout(_ profile: KLEProfile?) {
+        if let profile,
+           let data = profile.json.data(using: .utf8),
+           let keys = try? JSONDecoder().decode([KLEAbsoluteKey].self, from: data),
+           !keys.isEmpty {
+            activeKeys = keys
+            let maxX = keys.map { $0.cx + $0.w / 2 }.max() ?? 15
+            let maxY = keys.map { $0.cy + $0.h / 2 }.max() ?? 5
+            activeAspectRatio = CGFloat(maxX / maxY)
+            optimizerLayoutID = profile.id.uuidString
+        } else {
+            activeKeys = Self.ansiKeys
+            activeAspectRatio = Self.ansiAspectRatio
+            optimizerLayoutID = ""
+        }
+        reset()
     }
 
     /// Exports the current relocation map as a JSON preset to ~/Documents.
@@ -526,9 +557,31 @@ extension ChartsView {
                     .font(.footnote)
                     .foregroundStyle(.secondary)
 
+                // Layout picker — only shown when custom KLE profiles are available
+                if !optimizerKLEManager.profiles.isEmpty {
+                    HStack(spacing: 8) {
+                        Text(L10n.shared.optimizerLayoutPickerLabel)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Picker("", selection: Binding(
+                            get: { optimizerState.optimizerLayoutID },
+                            set: { id in
+                                let profile = optimizerKLEManager.profiles.first { $0.id.uuidString == id }
+                                optimizerState.applyLayout(profile)
+                            }
+                        )) {
+                            Text(L10n.shared.optimizerLayoutBuiltinANSI).tag("")
+                            ForEach(optimizerKLEManager.profiles) { profile in
+                                Text(profile.name).tag(profile.id.uuidString)
+                            }
+                        }
+                        .frame(maxWidth: 200)
+                    }
+                }
+
                 // KLE absolute-position rendering — same approach as heatmap custom template
-                let keys       = OptimizerSimulatorState.ansiKeys
-                let aspect     = OptimizerSimulatorState.ansiAspectRatio
+                let keys       = optimizerState.activeKeys
+                let aspect     = optimizerState.activeAspectRatio
                 let maxX       = CGFloat(keys.map { $0.cx + $0.w / 2 }.max() ?? 15)
 
                 Color.clear

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -40,6 +40,8 @@ struct ChartsView: View {
     @State var showThumbClusterConfig: Bool = false
     /// State object for the Key Swap Optimizer (Issue #235).
     @StateObject var optimizerState = OptimizerSimulatorState()
+    /// KLE profile manager for the Optimizer layout picker (Issue #373).
+    @StateObject var optimizerKLEManager = KLEProfileManager()
     /// Saved drill presets stored as JSON (Issue #278).
     @AppStorage(UDKeys.drillPresets) var drillPresetsJSON: String = "[]"
     /// Selected finger filter for the Slow Bigrams chart. nil = All (Issue #153).

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -2404,7 +2404,9 @@ final class L10n {
     var optimizerExportButton: String  { ja("レイアウトを保存",  en: "Export Layout") }
     var optimizerSwapCount: String     { ja("スワップ",          en: "swap(s)") }
     var optimizerExported: String      { ja("保存済み: ",        en: "Saved: ") }
-    var optimizerShowInFinder: String  { ja("Finderで表示",      en: "Show in Finder") }
+    var optimizerShowInFinder: String       { ja("Finderで表示",      en: "Show in Finder") }
+    var optimizerLayoutPickerLabel: String  { ja("レイアウト",        en: "Layout") }
+    var optimizerLayoutBuiltinANSI: String  { ja("内蔵 ANSI",         en: "Built-in ANSI") }
     var optimizerNoData: String        {
         ja("データ不足。しばらくタイプしてからお試しください。",
            en: "Not enough data yet. Type for a while first.")

--- a/Sources/KeyLens/UserDefaultsKeys.swift
+++ b/Sources/KeyLens/UserDefaultsKeys.swift
@@ -17,6 +17,7 @@ enum UDKeys {
     static let kleCustomLayoutURL          = "kleCustomLayoutURL"
     static let kleProfiles                 = "kleProfiles"
     static let kleSelectedProfileID        = "kleSelectedProfileID"
+    static let optimizerLayoutID           = "optimizerLayoutID"
     static let milestoneInterval           = "milestoneInterval"
     static let perfProfilingEnabled        = "perfProfilingEnabled"
     static let selectedChartTab            = "selectedChartTab"

--- a/docs/HowToBuild.md
+++ b/docs/HowToBuild.md
@@ -22,10 +22,13 @@ cd 262_KeyLens
 
 | Command | What it does |
 |---|---|
-| `./build.sh` | Build only |
-| `./build.sh --run` | Build and launch |
-| `./build.sh --install` | Build, install, sign, reset TCC, launch ← recommended |
-| `./build.sh --dmg` | Build distributable DMG |
+| `./build.sh` | Build only (debug) |
+| `./build.sh --run` | Build (debug) and launch |
+| `./build.sh --install` | Build (debug), install, sign, reset TCC, launch ← recommended |
+| `./build.sh --dmg` | Build (release) and create distributable DMG + ZIP |
+| `./build.sh --release` | Build DMG/ZIP and create a draft GitHub Release |
+| `./build.sh --release --publish` | Same, but publish immediately |
+| `./build.sh --clean` | Remove all build artifacts (`.build`, app, dmg, zip) |
 
 ## First-launch permissions
 


### PR DESCRIPTION
## Summary

- Added `activeKeys` / `activeAspectRatio` published properties to `OptimizerSimulatorState` — defaults to built-in ANSI, updated by `applyLayout()`
- Added `applyLayout(_ profile:)` — decodes `[KLEAbsoluteKey]` from a `KLEProfile` and switches the visual grid; resets swap history since slot identities change
- Added `optimizerLayoutID` persisted in `UserDefaults` so the layout choice survives restarts
- Added `optimizerKLEManager: KLEProfileManager` as `@StateObject` in `ChartsView`
- Added layout picker above the keyboard grid — only visible when custom profiles exist; selecting a profile calls `applyLayout()`
- Updated `displayAt` to iterate `activeKeys` instead of the static `ansiKeys`

## Notes

Ergonomic scoring always uses `ANSILayout()` finger assignments — KLE JSON encodes visual positions only, not finger mappings. The grid visualization adapts; the score model does not.

## Test plan

- [ ] No custom profiles loaded → picker does not appear, behavior unchanged
- [ ] Custom profile loaded → picker appears above grid with profile name
- [ ] Select custom profile → grid redraws with custom key positions, swap history resets
- [ ] Switch back to Built-in ANSI → ANSI grid restored
- [ ] Restart app → selected layout persists