### PR TITLE
feat: static effort cost overlay on Optimizer key tiles (#384)

### DIFF
--- a/Sources/KeyLens/Charts+OptimizerTab.swift
+++ b/Sources/KeyLens/Charts+OptimizerTab.swift
@@ -553,9 +553,15 @@ extension ChartsView {
             }
         } else {
             VStack(alignment: .leading, spacing: 8) {
-                Text(L10n.shared.optimizerInstruction)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                HStack {
+                    Text(L10n.shared.optimizerInstruction)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Toggle(L10n.shared.optimizerShowCostOverlay, isOn: $showCostOverlay)
+                        .toggleStyle(.checkbox)
+                        .font(.footnote)
+                }
 
                 // Layout picker — only shown when custom KLE profiles are available
                 if !optimizerKLEManager.profiles.isEmpty {
@@ -622,6 +628,10 @@ extension ChartsView {
 
         let fillColor: Color = {
             if isSelected { return Color.accentColor }
+            if showCostOverlay, let score = HeatmapExportView.effortScores[physSlot] {
+                let hue = 0.6 - (score / 10.0) * 0.6
+                return Color(hue: hue, saturation: 0.65, brightness: 0.9).opacity(0.45)
+            }
             if isLocked   { return Color.secondary.opacity(0.12) }
             if isChanged  { return Color.green.opacity(0.18) }
             if isModifier { return Color.blue.opacity(0.08) }

--- a/Sources/KeyLens/Charts+OptimizerTab.swift
+++ b/Sources/KeyLens/Charts+OptimizerTab.swift
@@ -585,6 +585,28 @@ extension ChartsView {
                     }
                 }
 
+                if showCostOverlay {
+                    HStack(spacing: 6) {
+                        Text(L10n.shared.optimizerCostEasy)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        LinearGradient(
+                            stops: [
+                                .init(color: Color(hue: 0.6, saturation: 0.65, brightness: 0.9), location: 0),
+                                .init(color: Color(hue: 0.3, saturation: 0.65, brightness: 0.9), location: 0.5),
+                                .init(color: Color(hue: 0.0, saturation: 0.65, brightness: 0.9), location: 1),
+                            ],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                        .frame(height: 8)
+                        .clipShape(Capsule())
+                        Text(L10n.shared.optimizerCostHard)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
                 // KLE absolute-position rendering — same approach as heatmap custom template
                 let keys       = optimizerState.activeKeys
                 let aspect     = optimizerState.activeAspectRatio

--- a/Sources/KeyLens/ChartsView.swift
+++ b/Sources/KeyLens/ChartsView.swift
@@ -81,6 +81,8 @@ struct ChartsView: View {
     /// Set of section titles that are currently collapsed (Issue #251).
     /// 折りたたまれているセクションのタイトルセット。
     @State var collapsedSections: Set<String> = []
+    /// Whether the static effort cost overlay is shown on Optimizer key tiles (#384).
+    @State var showCostOverlay: Bool = false
 
     /// Fixed width keeps the live IKI snapshot compact when copying to the clipboard.
     /// 最新20打鍵グラフのコピーサイズを安定させるための固定幅。

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -2407,6 +2407,7 @@ final class L10n {
     var optimizerShowInFinder: String       { ja("Finderで表示",      en: "Show in Finder") }
     var optimizerLayoutPickerLabel: String  { ja("レイアウト",        en: "Layout") }
     var optimizerLayoutBuiltinANSI: String  { ja("内蔵 ANSI",         en: "Built-in ANSI") }
+    var optimizerShowCostOverlay: String    { ja("コスト表示",        en: "Show Cost") }
     var optimizerNoData: String        {
         ja("データ不足。しばらくタイプしてからお試しください。",
            en: "Not enough data yet. Type for a while first.")

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -2408,6 +2408,8 @@ final class L10n {
     var optimizerLayoutPickerLabel: String  { ja("レイアウト",        en: "Layout") }
     var optimizerLayoutBuiltinANSI: String  { ja("内蔵 ANSI",         en: "Built-in ANSI") }
     var optimizerShowCostOverlay: String    { ja("コスト表示",        en: "Show Cost") }
+    var optimizerCostEasy: String           { ja("楽",               en: "Easy") }
+    var optimizerCostHard: String           { ja("難",               en: "Hard") }
     var optimizerNoData: String        {
         ja("データ不足。しばらくタイプしてからお試しください。",
            en: "Not enough data yet. Type for a while first.")


### PR DESCRIPTION
## Summary
- Adds a **Show Cost** checkbox above the Optimizer keyboard grid
- When enabled, each key tile is colored by static ergonomic effort (blue = easy, red = hard) using the same `HeatmapExportView.effortScores` data as the Effort mode in the Keyboard Heatmap
- Selected keys remain highlighted in accent color so swap interactions still work correctly

## Files changed
- `ChartsView.swift` — adds `@State var showCostOverlay: Bool = false`
- `Charts+OptimizerTab.swift` — toggle button in grid header; cost color blended into `fillColor`
- `L10n.swift` — adds `optimizerShowCostOverlay` bilingual string

## Test plan
- [ ] Open Charts → Ergonomics → Optimizer tab
- [ ] Check "Show Cost" — keys color from blue (home row / strong fingers) to red (number row / pinkies)
- [ ] Uncheck — colors revert to default state colors
- [ ] Select a key while overlay is on — selected key shows accent color as expected
- [ ] Swap two keys while overlay is on — swapped keys show green tint when overlay is off, cost color when on