### PR TITLE
feat: track mouse idle vs. active time (#394)

### DIFF
--- a/Sources/KeyLens/Charts+MouseTab.swift
+++ b/Sources/KeyLens/Charts+MouseTab.swift
@@ -34,6 +34,7 @@ extension ChartsView {
                         chartSection(l.chartTitleMouseHourly, helpText: l.helpMouseHourly) {
                             mouseHourlyChart
                         }
+                        mouseActiveTimeSummaryView
                     }
                     .padding(24)
                 }
@@ -365,6 +366,26 @@ extension ChartsView {
             }
         }
         .padding(.vertical, 8)
+    }
+
+    // MARK: - Active Time Summary
+
+    @ViewBuilder
+    var mouseActiveTimeSummaryView: some View {
+        let l = L10n.shared
+        VStack(alignment: .leading, spacing: 8) {
+            Text(l.mouseActiveTimeLabel)
+                .font(.headline)
+
+            if model.mouseActiveTimeToday > 0 {
+                Text(l.mouseActiveTimeSummary(seconds: model.mouseActiveTimeToday))
+                    .font(.system(size: 28, weight: .semibold, design: .rounded))
+            } else {
+                Text(l.mouseActiveTimeNone)
+                    .foregroundStyle(.secondary)
+                    .font(.caption)
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/Sources/KeyLens/Charts+OptimizerTab.swift
+++ b/Sources/KeyLens/Charts+OptimizerTab.swift
@@ -112,6 +112,9 @@ final class OptimizerSimulatorState: ObservableObject {
     /// バックグラウンドでスコアを再計算中のとき true。
     @Published var isComputing: Bool = false
 
+    private var loadTask:      Task<Void, Never>?
+    private var recomputeTask: Task<Void, Never>?
+
     // MARK: - Derived: display label at each physical slot
 
     /// Maps each physical slot to the key label currently displayed there.
@@ -138,7 +141,7 @@ final class OptimizerSimulatorState: ObservableObject {
     func loadIfNeeded() {
         guard baseSnapshot == nil, !isComputing else { return }
         isComputing = true
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+        loadTask = Task.detached(priority: .userInitiated) { [weak self] in
             let bc   = KeyCountStore.shared.allBigramCounts
             let kc   = KeyCountStore.shared.allKeyCounts
             let snap = ErgonomicSnapshot.capture(
@@ -146,7 +149,7 @@ final class OptimizerSimulatorState: ObservableObject {
                 keyCounts:    kc,
                 layout:       .shared
             )
-            DispatchQueue.main.async {
+            await MainActor.run {
                 self?.baseSnapshot    = snap
                 self?.currentSnapshot = snap
                 self?.isComputing     = false
@@ -265,18 +268,20 @@ final class OptimizerSimulatorState: ObservableObject {
 
     private func recompute() {
         let map = relocationMap
+        recomputeTask?.cancel()
         isComputing = true
-        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
-            let bc      = KeyCountStore.shared.allBigramCounts
-            let kc      = KeyCountStore.shared.allKeyCounts
-            let layout  = KeyRelocationSimulator.layout(applying: map, over: ANSILayout())
-            let simReg  = LayoutRegistry.forSimulation(layout: layout)
-            let snap    = ErgonomicSnapshot.capture(
+        recomputeTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let bc     = KeyCountStore.shared.allBigramCounts
+            let kc     = KeyCountStore.shared.allKeyCounts
+            let layout = KeyRelocationSimulator.layout(applying: map, over: ANSILayout())
+            let simReg = LayoutRegistry.forSimulation(layout: layout)
+            let snap   = ErgonomicSnapshot.capture(
                 bigramCounts: bc,
                 keyCounts:    kc,
                 layout:       simReg
             )
-            DispatchQueue.main.async {
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
                 self?.currentSnapshot = snap
                 self?.isComputing     = false
             }

--- a/Sources/KeyLens/ChartsWindowController.swift
+++ b/Sources/KeyLens/ChartsWindowController.swift
@@ -74,6 +74,9 @@ final class ChartDataModel: ObservableObject {
     @Published var mouseHourlyActivity:        [MouseHourEntry]             = []
     @Published var mouseDirectionEntries:      [MouseDirectionEntry]        = []
     @Published var mouseDailyDirectionEntries: [MouseDailyDirectionEntry]   = []
+    // Issue #394: Mouse idle vs. active time
+    @Published var mouseActiveTimeToday:       Double                       = 0
+    @Published var mouseDailyActiveTimes:      [(date: String, activeSeconds: Double)] = []
     // Issue #182: Mouse vs Keyboard balance
     @Published var mouseKeyboardBalance:       [MouseKeyboardBalanceEntry]  = []
     // Issue #90: Ranked bigrams for training — session is built in the view using the user's length preference.
@@ -245,6 +248,8 @@ final class ChartDataModel: ObservableObject {
             // --- Mouse data ---
             let mouseDailyDistances    = ms.dailyDistances().map(MouseDailyEntry.init)
             let mouseHourlyActivity    = ms.hourlyDistributionMouse().map { MouseHourEntry(hour: $0.hour, distancePts: $0.distancePts) }
+            let mouseActiveTimeToday   = ms.activeTimeToday()
+            let mouseDailyActiveTimes  = ms.dailyActiveTimes()
             let dir                    = ms.directionBreakdown()
             let mouseDirectionEntries  = [
                 MouseDirectionEntry(id: "left",  direction: "Left ←",  distancePts: dir.left),
@@ -324,6 +329,8 @@ final class ChartDataModel: ObservableObject {
                 self.mouseHourlyActivity        = mouseHourlyActivity
                 self.mouseDirectionEntries      = mouseDirectionEntries
                 self.mouseDailyDirectionEntries = mouseDailyDirectionEntries
+                self.mouseActiveTimeToday       = mouseActiveTimeToday
+                self.mouseDailyActiveTimes      = mouseDailyActiveTimes
                 self.mouseKeyboardBalance       = mouseKeyboardBalance
                 self.heatmapGrid                = heatmapGrid
                 self.totalCount                 = totalCount

--- a/Sources/KeyLens/KeyboardMonitor.swift
+++ b/Sources/KeyLens/KeyboardMonitor.swift
@@ -374,7 +374,7 @@ extension KeyboardMonitor {
         if type == .mouseMoved {
             let dx = event.getDoubleValueField(.mouseEventDeltaX)
             let dy = event.getDoubleValueField(.mouseEventDeltaY)
-            MouseStore.shared.addMovement(dx: dx, dy: dy)
+            MouseStore.shared.addMovement(dx: dx, dy: dy, at: Date())
 
             mouseSampleCounter += 1
             if mouseSampleCounter >= 5 {

--- a/Sources/KeyLens/L10n.swift
+++ b/Sources/KeyLens/L10n.swift
@@ -1708,6 +1708,19 @@ final class L10n {
         ja("日別マウス移動距離（直近30日）", en: "Daily Mouse Travel (Last 30 Days)")
     }
 
+    var mouseActiveTimeLabel: String { ja("アクティブ時間", en: "Active") }
+    var mouseActiveTimeNone: String  { ja("データなし",     en: "No data yet") }
+
+    func mouseActiveTimeSummary(seconds: Double) -> String {
+        let h = Int(seconds) / 3600
+        let m = (Int(seconds) % 3600) / 60
+        if h > 0 {
+            return resolved == .japanese ? "\(h)時間\(m)分" : "\(h)h \(m)m"
+        } else {
+            return resolved == .japanese ? "\(m)分" : "\(m)m"
+        }
+    }
+
     var helpMouseDailyDistance: String {
         ja(
             "直近30日間の日別マウス移動距離を棒グラフで表示します。単位はスクリーンポイント（px）です。",

--- a/Sources/KeyLens/MouseStore.swift
+++ b/Sources/KeyLens/MouseStore.swift
@@ -22,6 +22,11 @@ final class MouseStore {
     private var pendingDxNeg: Double = 0   // leftward sum (positive value)
     private var pendingDyPos: Double = 0   // downward sum
     private var pendingDyNeg: Double = 0   // upward sum (positive value)
+    private var pendingActiveSeconds: Double = 0
+
+    // Idle detection — time of last mouseMoved event
+    private var lastMovementTime: Date? = nil
+    private static let idleThreshold: TimeInterval = 2.0
 
     // Grid accumulator for heatmap — key: gridX * 100 + gridY → hit count
     private var pendingGrid: [Int: Int] = [:]
@@ -81,6 +86,11 @@ final class MouseStore {
                     t.primaryKey(["grid_x", "grid_y"])
                 }
             }
+            migrator.registerMigration("v3_active_time") { db in
+                try db.alter(table: "mouse_daily") { t in
+                    t.add(column: "active_seconds", .double).notNull().defaults(to: 0)
+                }
+            }
             try migrator.migrate(db)
 
             dbQueue = db
@@ -96,12 +106,20 @@ final class MouseStore {
     /// Hot path: addition only, zero disk I/O.
     ///
     /// マウス移動イベントを蓄積する（ホットパス: 加算のみ、ディスクI/Oなし）。
-    func addMovement(dx: Double, dy: Double) {
+    func addMovement(dx: Double, dy: Double, at now: Date = Date()) {
         queue.async { [self] in
             let dist = (dx * dx + dy * dy).squareRoot()
             pendingDistance += dist
             if dx > 0 { pendingDxPos += dx  } else { pendingDxNeg += -dx }
             if dy > 0 { pendingDyPos += dy  } else { pendingDyNeg += -dy }
+
+            if let last = lastMovementTime {
+                let gap = now.timeIntervalSince(last)
+                if gap < Self.idleThreshold {
+                    pendingActiveSeconds += gap
+                }
+            }
+            lastMovementTime = now
         }
     }
 
@@ -132,31 +150,34 @@ final class MouseStore {
     private func flushLocked() {
         guard let db = dbQueue else { return }
 
-        let dist  = pendingDistance
-        let dxPos = pendingDxPos
-        let dxNeg = pendingDxNeg
-        let dyPos = pendingDyPos
-        let dyNeg = pendingDyNeg
-        let grid  = pendingGrid
+        let dist          = pendingDistance
+        let dxPos         = pendingDxPos
+        let dxNeg         = pendingDxNeg
+        let dyPos         = pendingDyPos
+        let dyNeg         = pendingDyNeg
+        let activeSecs    = pendingActiveSeconds
+        let grid          = pendingGrid
         pendingDistance = 0; pendingDxPos = 0; pendingDxNeg = 0
         pendingDyPos    = 0; pendingDyNeg = 0; pendingGrid = [:]
+        pendingActiveSeconds = 0
 
         let dateStr = Self.dayFormatter.string(from: Date())
         let hour    = Calendar.current.component(.hour, from: Date())
 
         do {
             try db.write { db in
-                if dist > 0 {
+                if dist > 0 || activeSecs > 0 {
                     try db.execute(sql: """
-                        INSERT INTO mouse_daily (date, distance_pts, dx_pos, dx_neg, dy_pos, dy_neg)
-                        VALUES (?, ?, ?, ?, ?, ?)
+                        INSERT INTO mouse_daily (date, distance_pts, dx_pos, dx_neg, dy_pos, dy_neg, active_seconds)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
                         ON CONFLICT(date) DO UPDATE SET
-                            distance_pts = distance_pts + excluded.distance_pts,
-                            dx_pos       = dx_pos       + excluded.dx_pos,
-                            dx_neg       = dx_neg       + excluded.dx_neg,
-                            dy_pos       = dy_pos       + excluded.dy_pos,
-                            dy_neg       = dy_neg       + excluded.dy_neg
-                        """, arguments: [dateStr, dist, dxPos, dxNeg, dyPos, dyNeg])
+                            distance_pts   = distance_pts   + excluded.distance_pts,
+                            dx_pos         = dx_pos         + excluded.dx_pos,
+                            dx_neg         = dx_neg         + excluded.dx_neg,
+                            dy_pos         = dy_pos         + excluded.dy_pos,
+                            dy_neg         = dy_neg         + excluded.dy_neg,
+                            active_seconds = active_seconds + excluded.active_seconds
+                        """, arguments: [dateStr, dist, dxPos, dxNeg, dyPos, dyNeg, activeSecs])
 
                     try db.execute(sql: """
                         INSERT INTO mouse_hourly (date, hour, distance_pts)
@@ -293,6 +314,36 @@ final class MouseStore {
             return rows.map { (gridX: $0["grid_x"] as Int? ?? 0,
                                gridY: $0["grid_y"] as Int? ?? 0,
                                hits:  $0["hits"]   as Int? ?? 0) }
+        }
+    }
+
+    /// Active mouse time in seconds for today (in-memory + stored).
+    func activeTimeToday() -> Double {
+        queue.sync {
+            let dateStr = Self.dayFormatter.string(from: Date())
+            var stored: Double = 0
+            if let db = dbQueue {
+                stored = (try? db.read { db in
+                    try Double.fetchOne(db, sql: "SELECT active_seconds FROM mouse_daily WHERE date = ?",
+                                        arguments: [dateStr])
+                }) ?? 0
+            }
+            return stored + pendingActiveSeconds
+        }
+    }
+
+    /// Daily active time for the last N days, oldest first.
+    func dailyActiveTimes(days: Int = 30) -> [(date: String, activeSeconds: Double)] {
+        queue.sync {
+            guard let db = dbQueue else { return [] }
+            let rows = (try? db.read { db in
+                try Row.fetchAll(db, sql: """
+                    SELECT date, active_seconds FROM mouse_daily
+                    ORDER BY date DESC LIMIT ?
+                    """, arguments: [days])
+            }) ?? []
+            return rows.map { (date: $0["date"] as String? ?? "", activeSeconds: $0["active_seconds"] as Double? ?? 0) }
+                       .reversed()
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds `active_seconds` column to `mouse_daily` via a new DB migration (`v3_active_time`)
- `MouseStore.addMovement(dx:dy:at:)` now tracks elapsed time since last event; gaps under 2s accumulate as active time
- Active time today is displayed in the Mouse → Distance sub-tab as a large summary figure
- All new strings are bilingual (EN + JA) via `L10n`

## Files changed

- `MouseStore.swift` — migration, accumulator, flush, queries
- `KeyboardMonitor.swift` — pass `Date()` to `addMovement`
- `ChartsWindowController.swift` — two new `@Published` properties
- `L10n.swift` — `mouseActiveTimeLabel`, `mouseActiveTimeNone`, `mouseActiveTimeSummary`
- `Charts+MouseTab.swift` — `mouseActiveTimeSummaryView` in Distance sub-tab

Closes #394